### PR TITLE
Add check for terms accepted

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 import oauth2_provider.views
 import allauth.account.views
 
+from django.views.generic import TemplateView
+
 from sso.user.views import (
     LogoutView,
     LoginView,
@@ -126,6 +128,9 @@ api_urlpatterns = [
 
 
 urlpatterns = [
+    url(r"^terms_and_conditions$",
+        TemplateView.as_view(template_name="terms.html"),
+        name="terms"),
     url(
         r'^admin/',
         include(admin.site.urls)

--- a/sso/templates/terms.html
+++ b/sso/templates/terms.html
@@ -1,0 +1,162 @@
+{% extends './base.html' %}
+
+{% block body %}
+<div class="panel--great">
+
+	<h1 class="heading-large">Terms of use and privacy statement for UK Exporter Directory</h1>
+
+	<h2 class="heading-medium">Terms of use</h2>
+
+	<p class="lede">
+		The Department for International Trade is a government department that helps businesses based in the UK to do business outside the UK. The Department for International Trade also helps overseas investors to invest in the UK.
+	</p>
+
+	<p>
+		These terms of use explain how the Department for International Trade manages your enrolment for the UK Exporter Directory.
+	</p>
+
+	<ol class="list list-number">
+		<li>
+			The directory will be a publically available database of information about UK businesses that export goods or services.
+		</li>
+		<li>
+			These terms of use apply to the information used to <a href="https://directory.exportingisgreat.gov.uk/">register to be considered for inclusion in the directory</a>.
+		</li>
+		<li>
+			By submitting information through the form you agree to comply with, and be bound by these terms. By submitting information you also agree to the Department for International Trade using any it in ways set out in the <a href="#privacy-heading">privacy statement</a> (below).
+		</li>
+		<li>
+			The Department for International Trade reserves the right to determine whether the information you submit to us is suitable for inclusion on the directory.
+		</li>
+		<li>
+			The directory is due to be launched later in 2016. The Department for International Trade reserves the right to delay or cancel the project in its entirety. If the directory is delayed or cancelled, the Department for International Trade will try to notify you of that decision by email or by an announcement on the Department for International Trade website.
+		</li>
+		<li>
+			If you submit information, you must ensure that to the best of your knowledge, it is true and accurate.
+		</li>
+		<li>
+			By submitting an application, you grant the Department for International Trade a perpetual, worldwide, non-exclusive, royalty-free, transferable licence to use and manipulate the information to launch and maintain the directory. You also grant the Department for International Trade the right to use the information for the purposes of promotional or research purposes.
+		</li>
+		<li>
+			Any information which you submit for inclusion in the directory will not be treated as confidential or proprietary. You retain all of your ownership rights in your content (excepting the licence granted to us in paragraph 7 above). By submitting a completed form, you also understand and expressly permit the Department for International Trade to make the information publicly available.
+		</li>
+		<li>
+			The Department for International Trade reserves the right to amend or supplement these terms of use at any time.
+		</li>
+	</ol>
+
+
+	<h2 class="heading-medium" id="privacy-heading">Privacy Statement</h2>
+
+	<p>
+		This privacy statement explains how the Department for International Trade uses the information you submit when registering to be considered for inclusion in the directory.
+	</p>
+
+	<p>
+		The Department for International Trade will keep your information secure and manage it in line with our legal responsibilities. When you submit information, you agree to it being used and disclosed as set out below.
+	</p>
+
+	<h3 class="heading-small">The information the Department for International Trade collects and how it will be used</h3>
+
+	<p>
+		The Department for International Trade collects information we need to decide whether to include your information in the directory.  The information the Department for International Trade has asked for may be used to create an entry relating to your business on the directory.
+	</p>
+
+	<p>
+		You are not required to provide all of this information. However, providing full information will make your company more likely to be included in the directory.
+	</p>
+
+	<p>
+		You understand that, if your enrolment is successful, the information above will be made available to the public.
+	</p>
+
+	<p>
+		The Department for International Trade will also ask organisations that are included in the directory for more information that will not be published in the directory. This information may include questions about:
+	</p>
+
+	<ul class="list list-bullet list-inset">
+		<li>your organisation’s experience of exporting</li>
+		<li>how often your organisation exports</li>
+		<li>how much of your organisation’s turnover is from to exports</li>
+		<li>which destinations your organisation exports to</li>
+	</ul>
+
+	<p>
+		This information will be used by  the Department for International Trade staff to research and analyse the characteristics and behaviour of exporting businesses.
+	</p>
+
+	<p>
+		Reports produced from this information will only include aggregated data, from which it will not be possible to identify individuals or individual businesses.
+	</p>
+
+	<h3 class="heading-small">Who might see or use your information</h3>
+
+	<p>
+		Information about you and your company may be reviewed members of Department for International Trade staff and staff at other UK government departments to determine your inclusion in the directory.
+	</p>
+
+	<p>
+		The directory will be created with &quot;third-party&quot; organisations (organisations that are not part of HM Government), for example, internet hosting services and website developers. Your information may be seen by staff at these organisations.
+	</p>
+
+	<p>
+		We have developed the directory in co-operation with commercial partners. These partners may review applications before the public launch of the directory.
+	</p>
+
+	<p>
+		The directory will be accessible to the public, including any information about your business.
+	</p>
+
+	<h3 class="heading-small">How the Department for International Trade contacts you</h3>
+
+	<p>
+		The Department for International Trade may contact you to update you on your application, and with news about the progress of the directory.
+	</p>
+
+	<p>
+		If you consent to receive them UKTI may also get in touch with you in relation to its other campaigns, and other services or products which it offers or intends to offer.
+	</p>
+
+	<p>
+		You can opt out of these messages using the unsubscribe link included in the Department for International Trade’s emails, or by writing to:
+	</p>
+
+	<p>
+		The Department for International Trade<br>
+		1 Victoria Street<br>
+		London<br>
+		SW1H 0ET
+	</p>
+
+	<h3 class="heading-small">How the Department for International Trade keeps your information secure</h3>
+
+	<p>
+		The Department for International Trade is committed to handling your personal information and data with care – trying to protect your personal information, from loss, misuse, unauthorised access, modification or disclosure.
+	</p>
+
+	<p>
+		The directory information is designed to be publicly available and the Department for International Trade is not responsible for unauthorised or unintended access to or use of your information by other organisations or people.
+	</p>
+
+	<h3 class="heading-small">Your rights about your personal information</h3>
+
+	<p>
+		Your rights are set out in the <a href="http://www.legislation.gov.uk/ukpga/1998/29/contents">Data Protection Act 1998</a>. The Department for International Trade acts as the “data controller” under the act for any personal information submit for enrolment or that are included on the directory.
+	</p>
+
+	<p>
+		This means that you can ask for a copy of your personal information from us, and details of how the Department for International Trade uses that information. Copies of your information and details of use cost &pound;10, payable in advance.
+	</p>
+
+	<p>
+		If you think any of the personal information the Department for International Trade holds about you is inaccurate, you may request it is corrected.
+	</p>
+
+	<p>
+		If you want to request your information or to make a correction, please <a href="https://www.contactus.ukti.gov.uk/enquiry/topic">contact us</a>.
+	</p>
+
+
+</div>
+
+{% endblock body %}

--- a/sso/user/forms.py
+++ b/sso/user/forms.py
@@ -1,4 +1,5 @@
-from django.forms import ValidationError
+from django.forms import BooleanField, ValidationError
+from django.utils.safestring import mark_safe
 
 from allauth.account import forms
 
@@ -8,6 +9,14 @@ class IndentedInvalidFieldsMixin:
 
 
 class SignupForm(IndentedInvalidFieldsMixin, forms.SignupForm):
+    terms_agreed = BooleanField(
+        label=mark_safe(
+            'Tick this box to accept the '
+            '<a href="/terms_and_conditions" target="_blank">terms and '
+            'conditions</a> of the exporting is GREAT service.'
+        )
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['password2'].label = 'Confirm password:'

--- a/sso/user/tests/test_forms.py
+++ b/sso/user/tests/test_forms.py
@@ -2,6 +2,11 @@ import pytest
 
 from sso.user import forms
 
+from django.forms.fields import Field
+
+
+REQUIRED_MESSAGE = Field.default_error_messages['required']
+
 
 def test_signup_form_email_twice():
     form = forms.SignupForm()
@@ -37,3 +42,17 @@ def test_password_reset_form_customization():
 
     assert form.is_valid() is False
     assert form.errors['email'] == [expected]
+
+
+def test_signup_rejects_missing_terms_agreed():
+    form = forms.SignupForm(data={})
+
+    assert form.is_valid() is False
+    assert form.errors['terms_agreed'] == [REQUIRED_MESSAGE]
+
+
+def test_signup_accepts_present_terms_agreed():
+    form = forms.SignupForm(data={'terms_agreed': True})
+
+    assert form.is_valid() is False
+    assert 'terms_agreed' not in form.errors

--- a/sso/user/tests/test_views.py
+++ b/sso/user/tests/test_views.py
@@ -214,6 +214,7 @@ def test_confirm_email_redirect_next_param_if_next_param_valid(
         data={
             'email': 'jim@example.com',
             'email2': 'jim@example.com',
+            'terms_agreed': True,
             'password1': '0123456',
             'password2': '0123456',
         }
@@ -251,6 +252,7 @@ def test_confirm_email_redirect_next_param_if_next_param_invalid(
         data={
             'email': 'jim@example.com',
             'email2': 'jim@example.com',
+            'terms_agreed': True,
             'password1': '0123456',
             'password2': '0123456',
         }
@@ -288,6 +290,7 @@ def test_confirm_email_redirect_next_param_if_next_param_internal(
         data={
             'email': 'jim@example.com',
             'email2': 'jim@example.com',
+            'terms_agreed': True,
             'password1': '0123456',
             'password2': '0123456',
         }
@@ -318,6 +321,7 @@ def test_confirm_email_redirect_default_param_if_no_next_param(
         data={
             'email': 'jim@example.com',
             'email2': 'jim@example.com',
+            'terms_agreed': True,
             'password1': '0123456',
             'password2': '0123456',
         }

--- a/static/main.css
+++ b/static/main.css
@@ -10,7 +10,8 @@ html {
   box-sizing: inherit;
 }
 
-ul, li {
+.sso-header li,
+.sso-footer li {
   list-style: none;
 }
 


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-295)

I considered linking to UI's terms, but that would add extra complexity that is easily solved by duplicating the view here.

![image](https://cloud.githubusercontent.com/assets/5485798/20058407/c396008a-a4e8-11e6-911c-fde8ec53aebb.png)
