### PR TITLE
Set field order of signup form

### DIFF
--- a/sso/user/forms.py
+++ b/sso/user/forms.py
@@ -2,6 +2,7 @@ from django.forms import BooleanField, ValidationError
 from django.utils.safestring import mark_safe
 
 from allauth.account import forms
+from allauth.utils import set_form_field_order
 
 
 class IndentedInvalidFieldsMixin:
@@ -16,10 +17,19 @@ class SignupForm(IndentedInvalidFieldsMixin, forms.SignupForm):
             'conditions</a> of the exporting is GREAT service.'
         )
     )
+    field_order = [
+        'email',
+        'email2',
+        'password1',
+        'password2',
+        'terms_agreed',
+    ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['password2'].label = 'Confirm password:'
+        self.fields['email2'].label = 'Confirm email:'
+        set_form_field_order(self, self.field_order)
 
 
 class LoginForm(IndentedInvalidFieldsMixin, forms.LoginForm):

--- a/sso/user/tests/test_forms.py
+++ b/sso/user/tests/test_forms.py
@@ -56,3 +56,14 @@ def test_signup_accepts_present_terms_agreed():
 
     assert form.is_valid() is False
     assert 'terms_agreed' not in form.errors
+
+
+def test_signup_field_order():
+    expected_field_order = [
+        'email',
+        'email2',
+        'password1',
+        'password2',
+        'terms_agreed',
+    ]
+    assert forms.SignupForm.field_order == expected_field_order


### PR DESCRIPTION
currently the 'confirm email' field is after the 'agree' button.

![image](https://cloud.githubusercontent.com/assets/5485798/20067681/081ceb68-a50e-11e6-9dd1-95833ac1bb62.png)
