### PR TITLE
Serve email staticfiles from s3

### DIFF
--- a/sso/constants.py
+++ b/sso/constants.py
@@ -5,3 +5,8 @@ FEEDBACK_FORM_URL = (
 TERMS_AND_CONDITIONS_URL = (
     'https://www.exportingisgreat.gov.uk/terms-and-conditions/'
 )
+
+EMAIL_HEADER_IMAGE = (
+    'https://s3-eu-west-1.amazonaws.com/directory-email-static/'
+    'eig-logo-stacked.png'
+)

--- a/sso/templates/base_email_cta.html
+++ b/sso/templates/base_email_cta.html
@@ -1,4 +1,4 @@
-	{% load static %}
+	{% load header_image from sso_email %}
 	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 	<html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
@@ -223,7 +223,7 @@
 												<table border="0" cellpadding="0" cellspacing="0" width="500" class="flexibleContainer">
 													<tr>
 														<td align="center" valign="top" width="500" class="flexibleContainerCell">
-															<img src="{% static 'images/EiG-logo-stacked.png'%}" style="height: 100px; margin: 20px;"/>
+															<img src="{% header_image %}" style="height: 100px; margin: 20px;"/>
 
 														</td>
 													</tr>

--- a/sso/templatetags/sso_email.py
+++ b/sso/templatetags/sso_email.py
@@ -1,0 +1,9 @@
+from django import template
+from sso import constants
+
+register = template.Library()
+
+
+@register.simple_tag
+def header_image():
+    return constants.EMAIL_HEADER_IMAGE

--- a/sso/tests/test_template_tags.py
+++ b/sso/tests/test_template_tags.py
@@ -1,4 +1,10 @@
-from ..templatetags.sso_validation import is_valid_redirect_domain
+from sso.templatetags.sso_validation import is_valid_redirect_domain
+from sso.templatetags.sso_email import header_image
+from sso import constants
+
+
+def test_header_image_returns_constant_image():
+    assert header_image() == constants.EMAIL_HEADER_IMAGE
 
 
 def test_is_valid_returns_true_when_domain_valid(settings):


### PR DESCRIPTION
`{% static` returns a relative url. That does not work for emails.