### PR TITLE
Fix missing next param in password reset url

### DIFF
--- a/sso/templates/account/email/password_reset_key_message.html
+++ b/sso/templates/account/email/password_reset_key_message.html
@@ -2,7 +2,7 @@
 {% load sso_validation %}
 
 {% block cta_url %}
-    {{ password_reset_url }}{% if request.GET.next|is_valid_redirect_domain %}?next={{request.GET.next}}{% endif %}
+    {{ password_reset_url }}{% if request.POST.next|is_valid_redirect_domain %}?next={{request.POST.next}}{% endif %}
 {% endblock %}
 {% block cta_label %}Reset password{% endblock %}
 {% block title %}Your Exporting is Great account{% endblock %}

--- a/sso/templates/account/email/password_reset_key_message.txt
+++ b/sso/templates/account/email/password_reset_key_message.txt
@@ -4,6 +4,6 @@ Your great.gov.uk export services account
 
 You are receiving this email because you or someone else has requested a password for your user account. Follow the link below to reset your password.
 
-{{ password_reset_url }}{% if request.GET.next|is_valid_redirect_domain %}?next={{request.GET.next}}{% endif %}
+{{ password_reset_url }}{% if request.POST.next|is_valid_redirect_domain %}?next={{request.POST.next}}{% endif %}
 
 You received this email because you set up an account on great.gov.uk


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/ED-635

I was hoping to add somekind of bulletproof test for this not happening in the future, but since the problem was whether the next param comes through a POST or a GET and we have to specify what comes in GET and what comes in POST to django test client to run a test, this basically needs to be done in integration testing.