### PR TITLE
Add missing context processor

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -76,6 +76,8 @@ TEMPLATES = [
                 'sso.user.context_processors.redirect_next_processor',
                 'sso.context_processors.analytics',
                 'sso.context_processors.feature_flags',
+                ('directory_header_footer.context_processors.'
+                 'header_footer_context_processor'),
             ],
             'loaders': [
                 'django.template.loaders.filesystem.Loader',


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-1550)

The header and footer context processor exposes the "contact us" value to the footer template.