### PR TITLE
Update allauth

### DIFF
--- a/requirements.ini
+++ b/requirements.ini
@@ -1,6 +1,6 @@
 dj-database-url==0.4.1
 Django==1.9.13
-django-allauth==0.28.0
+django-allauth==0.33.0
 djangorestframework==3.4.7
 django-oauth-toolkit==0.10.0
 django-cors-headers==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ boto3==1.4.0
 botocore==1.4.93          # via boto3, s3transfer
 contextlib2==0.5.5        # via raven
 dj-database-url==0.4.1
-django-allauth==0.28.0
+django-allauth==0.33.0
 django-braces==1.11.0     # via django-oauth-toolkit
 django-cors-headers==1.2.2
 django-filter==1.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,7 +16,7 @@ contextlib2==0.5.5        # via raven
 coverage==4.4.1           # via codecov, pytest-cov
 defusedxml==0.5.0         # via python3-openid
 dj-database-url==0.4.1
-django-allauth==0.28.0
+django-allauth==0.33.0
 django-braces==1.11.0     # via django-oauth-toolkit
 django-cors-headers==1.2.2
 django-filter==1.0.1


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-2089)

looks like this is an allauth bug, fixed by this PR: https://github.com/pennersr/django-allauth/pull/1711

the user is trying to log in, but they have not yet clicked the email confirmation link.

allauth then hits their buggy code that tries to create a duplicate `EmailAddress` instance.

They have fixed this in their master branch:

our current version of allauth.account.managers.EmailAddressManager.add_email
```py
try:
    email_address = self.get(user=user, email__iexact=email)
except self.model.DoesNotExist:
    email_address = self.create(user=user, email=email)
```

allauth's master branch
```py
email_address, created = self.get_or_create(
    user=user, email__iexact=email, defaults=
    {"email": email}
)
```

https://github.com/pennersr/django-allauth/blob/master/allauth/account/managers.py