### PR TITLE
Improve header parity

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1,3 +1,6 @@
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,700);
+@import url(https://fonts.googleapis.com/css?family=Overpass:400,800);
+
 html {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;


### PR DESCRIPTION
SSO's header looks slightly different to the other services because it's missing some common styling.