### PR TITLE
Add ping view for healthcheck

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -13,7 +13,7 @@ from sso.user.views import (
     SSOLandingPage,
     SignupView,
 )
-from sso.healthcheck.views import HealthCheckAPIView
+from sso.healthcheck.views import HealthCheckAPIView, PingAPIView
 from sso.oauth2.views_user import UserRetrieveAPIView
 from sso.api.views_user import (
     SessionUserAPIView, LastLoginAPIView, PasswordCheckAPIView
@@ -110,6 +110,11 @@ api_urlpatterns = [
         r'^$',
         HealthCheckAPIView.as_view(),
         name='health-check'
+    ),
+    url(
+        r'^ping/$',
+        PingAPIView.as_view(),
+        name='health-check-ping'
     ),
     url(
         r'^session-user/$',

--- a/sso/healthcheck/tests/test_views.py
+++ b/sso/healthcheck/tests/test_views.py
@@ -1,11 +1,9 @@
 from django.core.urlresolvers import reverse
 
 from rest_framework import status
-from rest_framework.test import APIClient
 
 
-def test_health_check():
-    client = APIClient()
+def test_health_check(client):
     response = client.get(reverse('health-check'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -13,3 +11,9 @@ def test_health_check():
     response_data = response.data
     assert response_data['status_code'] == status.HTTP_200_OK
     assert response_data['detail'] == 'Hello world'
+
+
+def test_ping(client):
+    response = client.get(reverse('health-check-ping'))
+
+    assert response.status_code == status.HTTP_200_OK

--- a/sso/healthcheck/views.py
+++ b/sso/healthcheck/views.py
@@ -2,6 +2,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from config.signature import SignatureCheckPermission
+
 
 class HealthCheckAPIView(APIView):
     permission_classes = []
@@ -16,3 +18,12 @@ class HealthCheckAPIView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+class PingAPIView(APIView):
+
+    permission_classes = (SignatureCheckPermission, )
+    http_method_names = ("get", )
+
+    def get(self, request, *args, **kwargs):
+        return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
[part of this task](https://uktrade.atlassian.net/browse/ED-2933)

This will be used by FAB to determine if FAB can communicate with API.

FAB is not using the healthcheck view because that has different permission requirements:
 - healthcheck: permission determined via querystring value
 - ping: permission determined via signature