### PR TITLE
fix python buildpack version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,3 @@
 ---
 applications:
-  - buildpack: python_buildpack
+  - buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.25


### PR DESCRIPTION
Lock down the buildpack version so not affected by GDS upgrades.