### PR TITLE
Add questions to Django Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Pre release
+
+### Enhancements
+
+- GP2-2176 - Value for Money Questions
 ### Fixed bugs
 
 ## [v6.4.0](https://github.com/uktrade/directory-sso/releases/tag/v6.4.0)

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     'directory_components',
     'authbroker_client',
     'sort_order_field',
+    'django_json_widget',
 ]
 
 SITE_ID = 1

--- a/requirements.in
+++ b/requirements.in
@@ -30,3 +30,4 @@ celery[redis]==4.3.0
 django-celery-beat==1.5.0
 cryptography==3.3.2
 django-sort-order-field==1.2
+django_json_widget==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,6 +103,8 @@ django==2.2.19
     #   django-timezone-field
     #   djangorestframework
     #   sigauth
+django_json_widget==1.1.1
+    # via -r requirements.in
 djangorestframework==3.12.2
     # via
     #   -r requirements.in
@@ -112,7 +114,9 @@ docopt==0.6.2
 docutils==0.15.2
     # via botocore
 future==0.18.2
-    # via notifications-python-client
+    # via
+    #   django-json-widget
+    #   notifications-python-client
 gunicorn==20.0.4
     # via -r requirements.in
 idna==2.10

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -123,6 +123,8 @@ django==2.2.19
     #   django-timezone-field
     #   djangorestframework
     #   sigauth
+django_json_widget==1.1.1
+    # via -r requirements.in
 djangorestframework==3.12.2
     # via
     #   -r requirements.in
@@ -142,7 +144,9 @@ flake8==3.8.4
 freezegun==1.1.0
     # via -r requirements_test.in
 future==0.18.2
-    # via notifications-python-client
+    # via
+    #   django-json-widget
+    #   notifications-python-client
 gunicorn==20.0.4
     # via -r requirements.in
 idna==2.10

--- a/sso/user/admin.py
+++ b/sso/user/admin.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django_json_widget.widgets import JSONEditorWidget
 
-from sso.user.models import DataRetentionStatistics, Question, User, UserProfile
+from sso.user.models import DataRetentionStatistics, Question, User, UserAnswer, UserProfile
 
 
 class GDPRComplianceFilter(admin.SimpleListFilter):
@@ -166,3 +166,8 @@ class QuestionAdmin(admin.ModelAdmin):
     formfield_overrides = {
         fields.JSONField: {'widget': JSONEditorWidget},
     }
+
+
+@admin.register(UserAnswer)
+class AnswerAdmin(admin.ModelAdmin):
+    pass

--- a/sso/user/admin.py
+++ b/sso/user/admin.py
@@ -4,10 +4,12 @@ import datetime
 from directory_api_client import api_client
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.postgres import fields
 from django.http import HttpResponse
 from django.utils import timezone
+from django_json_widget.widgets import JSONEditorWidget
 
-from sso.user.models import DataRetentionStatistics, User, UserProfile
+from sso.user.models import DataRetentionStatistics, Question, User, UserProfile
 
 
 class GDPRComplianceFilter(admin.SimpleListFilter):
@@ -157,3 +159,10 @@ class UserAdmin(admin.ModelAdmin):
         )
 
     download_password_reset_links.short_description = "Download password reset links for selected users"
+
+
+@admin.register(Question)
+class QuestionAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        fields.JSONField: {'widget': JSONEditorWidget},
+    }

--- a/sso/user/fixtures/questions.json
+++ b/sso/user/fixtures/questions.json
@@ -59,12 +59,12 @@
           "value": "sole-trader"
         },
         {
-          "label": "My business or organisation is not registered in the UK",
+          "label": "I pay taxes in the UK but do not represent a business",
           "value": "no-business",
           "jump": "end"
         },
         {
-          "label": "I do not have a product or service for export",
+          "label": "My business or organisation is not registered in the UK",
           "value": "non-uk",
           "jump": "end"
         }
@@ -207,7 +207,7 @@
     "pk": 7,
     "fields": {
       "service": 1,
-      "name": "sufficient_demand",
+      "name": "sufficient-demand",
       "title": "To what extent do you agree or disagree there would not be enough demand for my business overseas to make it worthwhile?",
       "question_type": "RADIO",
       "question_choices": {
@@ -243,7 +243,7 @@
     "pk": 8,
     "fields": {
       "service": 1,
-      "name": "interested in support",
+      "name": "interested-in-support",
       "title": "How interested would your business be in information and business support services that can assist you with exporting?",
       "question_type": "RADIO",
       "question_choices": [
@@ -269,7 +269,7 @@
     "pk": 9,
     "fields": {
       "service": 1,
-      "name": "business unit location",
+      "name": "business-unit-location",
       "title": "Where is the business unit that you regularly work in located?",
       "question_type": "SELECT",
       "predefined_choices": "EXPERTISE_REGION_CHOICES",
@@ -291,7 +291,7 @@
     "pk": 10,
     "fields": {
       "service": 1,
-      "name": "business location",
+      "name": "business-location",
       "title": "Where is the business located?",
       "question_type": "SELECT",
       "predefined_choices": "EXPERTISE_REGION_CHOICES",
@@ -307,7 +307,7 @@
     "pk": 11,
     "fields": {
       "service": 1,
-      "name": "Company turnover",
+      "name": "company-turnover",
       "title": "What is your organisation’s annual turnover?",
       "question_type": "RADIO",
       "predefined_choices": "TURNOVER_CHOICES",
@@ -320,7 +320,7 @@
     "pk": 12,
     "fields": {
       "service": 1,
-      "name": "Company turnover",
+      "name": "employee-count",
       "title": "How many employees are on your organisation’s payroll?",
       "question_type": "RADIO",
       "question_choices": [

--- a/sso/user/models.py
+++ b/sso/user/models.py
@@ -223,10 +223,10 @@ class LessonCompleted(TimeStampedModel):
 
 
 QUESTION_TYPES = [
-    ('RADIO', 'radio'),
-    ('SELECTION', 'Selection'),
-    ('MULTIPLE_SELECTOR', 'Multiple selection'),
-    ('TEXT', 'text'),
+    ('RADIO', 'Radio'),
+    ('SELECT', 'Select'),
+    ('MULTI_SELECT', 'Multi select'),
+    ('TEXT', 'Text'),
     ('COMPANY_LOOKUP', 'Company lookup'),
 ]
 
@@ -251,7 +251,8 @@ class Question(TimeStampedModel):
         ordering = ('sort_order',)
 
     def __str__(self):
-        return str(self.name)
+        inactive = '(inactive) ' if not self.is_active else ''
+        return f'{inactive}{str(self.name)}'
 
     def to_dict(self):
         question_options = (
@@ -277,8 +278,11 @@ class UserAnswer(TimeStampedModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     answer = JSONField(blank=True, default=dict)
 
+    class Meta:
+        ordering = ('user', 'question__sort_order')
+
     def to_dict(self):
         return {'question_id': self.question.id, 'answer': self.answer}
 
     def __str__(self):
-        return str(f'{self.user}:{self.question.name}')
+        return str(f'{self.user} : {self.question.name}')

--- a/sso/user/tests/test_models.py
+++ b/sso/user/tests/test_models.py
@@ -156,5 +156,5 @@ def test_user_answer_object():
 
     expected = UserAnswer.objects.create(**data)
 
-    assert str(expected) == str(f'{user}:{question}')
+    assert str(expected) == str(f'{user} : {question}')
     assert expected.to_dict()['question_id'] == question.id


### PR DESCRIPTION
This changeset enables management of `Question` objects from Django Admin.

To do:

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] Upgraded any vulnerable dependencies.
 - [x] Requirements have been compiled.
 - [ ] CSS have been compiled.
 - [ ] Change is accessible to the standards we subscribe to.
 - [ ] Added any new environment variable to vault.
 - [ ] Cleaned up old flags
 - [ ] Add a printscreen to the PR
 - [ ] Has made PR into develop too
