### PR TITLE
GP2-2353 VFM final page back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- GP2-2353 - VFM final page back button
 - GP2-2256 - magna header for BAU pages
 - GP2-2332 - upgraded directory-components package
 ### Fixed bugs

--- a/sso/user/fixtures/questions.json
+++ b/sso/user/fixtures/questions.json
@@ -1,420 +1,428 @@
-[
 {
-  "model": "user.question",
-  "pk": 0,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "in-progress",
-    "title": "MARK PROGRESS",
-    "question_type": "",
-    "question_choices":
-    {},
-    "predefined_choices": null,
-    "is_active": false,
-    "sort_order": 0
-  }
+    "model": "user.question",
+    "pk": 0,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "in-progress",
+        "title": "MARK PROGRESS",
+        "question_type": "",
+        "question_choices": {},
+        "predefined_choices": null,
+        "is_active": false,
+        "sort_order": 0
+    }
 },
 {
-  "model": "user.question",
-  "pk": 2,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "segment",
-    "title": "Which best describes you?",
-    "question_type": "RADIO",
-    "question_choices": [
-    {
-      "label": "I have exported in the last 12 months",
-      "value": "SUSTAIN"
-    },
-    {
-      "label": "I have exported before but not in the last 12 months",
-      "value": "REASSURE"
-    },
-    {
-      "label": "I have never exported but have a product or service that is suitable or that could be developed for export",
-      "value": "PROMOTE"
-    },
-    {
-      "jump": "end",
-      "label": "I do not have a product or service for export",
-      "value": "CHALLENGE"
-    }],
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 1
-  }
+    "model": "user.question",
+    "pk": 2,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "segment",
+        "title": "Which best describes you?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "I have exported in the last 12 months",
+                "value": "SUSTAIN"
+            },
+            {
+                "label": "I have exported before but not in the last 12 months",
+                "value": "REASSURE"
+            },
+            {
+                "label": "I have never exported but have a product or service that is suitable or that could be developed for export",
+                "value": "PROMOTE"
+            },
+            {
+                "jump": "end",
+                "label": "I do not have a product or service for export",
+                "value": "CHALLENGE"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 1
+    }
 },
 {
-  "model": "user.question",
-  "pk": 3,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "business-type",
-    "title": "What type of business are you representing?",
-    "question_type": "RADIO",
-    "question_choices": [
-    {
-      "label": "I represent a limited company (Ltd), a public limited company (PLC) or a Royal Charter company",
-      "value": "PLC"
-    },
-    {
-      "label": "I'm a sole trader or I represent another type of UK business not registered with Companies House",
-      "value": "sole-trader"
-    },
-    {
-      "jump": "end",
-      "label": "I pay taxes in the UK but do not represent a business",
-      "value": "no-business"
-    },
-    {
-      "jump": "end",
-      "label": "My business or organisation is not registered in the UK",
-      "value": "non-uk"
-    }],
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 2
-  }
+    "model": "user.question",
+    "pk": 3,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "business-type",
+        "title": "What type of business are you representing?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "I represent a limited company (Ltd), a public limited company (PLC) or a Royal Charter company",
+                "value": "PLC"
+            },
+            {
+                "label": "I'm a sole trader or I represent another type of UK business not registered with Companies House",
+                "value": "sole-trader"
+            },
+            {
+                "jump": "end",
+                "label": "I pay taxes in the UK but do not represent a business",
+                "value": "no-business"
+            },
+            {
+                "jump": "end",
+                "label": "My business or organisation is not registered in the UK",
+                "value": "non-uk"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 2
+    }
 },
 {
-  "model": "user.question",
-  "pk": 4,
-  "fields":
-  {
-    "created": null,
-    "modified": "2021-04-17T21:42:27.415Z",
-    "service": 1,
-    "name": "export-knowledge",
-    "title": "How would you rate your knowledge of where to go for help and support with exporting?",
-    "question_type": "SELECT",
-    "question_choices":
-    {
-      "options": [
-      {
-        "label": "0 (no knowledge at all)",
-        "value": "0"
-      },
-      {
-        "label": "1",
-        "value": "1"
-      },
-      {
-        "label": "2",
-        "value": "2"
-      },
-      {
-        "label": "3",
-        "value": "3"
-      },
-      {
-        "label": "4",
-        "value": "4"
-      },
-      {
-        "label": "5",
-        "value": "5"
-      },
-      {
-        "label": "6",
-        "value": "6"
-      },
-      {
-        "label": "7",
-        "value": "7"
-      },
-      {
-        "label": "8",
-        "value": "8"
-      },
-      {
-        "label": "9",
-        "value": "9"
-      },
-      {
-        "label": "10",
-        "value": "10"
-      }],
-      "placeholder": "Select one"
-    },
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 3
-  }
+    "model": "user.question",
+    "pk": 4,
+    "fields": {
+        "created": null,
+        "modified": "2021-04-17T21:42:27.415Z",
+        "service": 1,
+        "name": "export-knowledge",
+        "title": "How would you rate your knowledge of where to go for help and support with exporting?",
+        "question_type": "SELECT",
+        "question_choices": {
+            "options": [
+                {
+                    "label": "0 (no knowledge at all)",
+                    "value": "0"
+                },
+                {
+                    "label": "1",
+                    "value": "1"
+                },
+                {
+                    "label": "2",
+                    "value": "2"
+                },
+                {
+                    "label": "3",
+                    "value": "3"
+                },
+                {
+                    "label": "4",
+                    "value": "4"
+                },
+                {
+                    "label": "5",
+                    "value": "5"
+                },
+                {
+                    "label": "6",
+                    "value": "6"
+                },
+                {
+                    "label": "7",
+                    "value": "7"
+                },
+                {
+                    "label": "8",
+                    "value": "8"
+                },
+                {
+                    "label": "9",
+                    "value": "9"
+                },
+                {
+                    "label": "10",
+                    "value": "10"
+                }
+            ],
+            "placeholder": "Select one"
+        },
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 3
+    }
 },
 {
-  "model": "user.question",
-  "pk": 5,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "excitement",
-    "title": "To what extent do you agree or disagree that international growth is an exciting prospect for my business?",
-    "question_type": "RADIO",
-    "question_choices": [
-    {
-      "label": "Strongly agree",
-      "value": "5"
-    },
-    {
-      "label": "Somewhat agree",
-      "value": "4"
-    },
-    {
-      "label": "Neither agree nor disagree",
-      "value": "3"
-    },
-    {
-      "label": "Somewhat disagree",
-      "value": "2"
-    },
-    {
-      "label": "Strongly disagree",
-      "value": "1"
-    }],
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 4
-  }
+    "model": "user.question",
+    "pk": 5,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "excitement",
+        "title": "To what extent do you agree or disagree that international growth is an exciting prospect for my business?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "Strongly agree",
+                "value": "5"
+            },
+            {
+                "label": "Somewhat agree",
+                "value": "4"
+            },
+            {
+                "label": "Neither agree nor disagree",
+                "value": "3"
+            },
+            {
+                "label": "Somewhat disagree",
+                "value": "2"
+            },
+            {
+                "label": "Strongly disagree",
+                "value": "1"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 4
+    }
 },
 {
-  "model": "user.question",
-  "pk": 6,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "opportunity",
-    "title": "To what extent do you agree or disagree there is a lot of opportunity for my business to grow internationally?",
-    "question_type": "RADIO",
-    "question_choices": [
-    {
-      "label": "Strongly agree",
-      "value": "5"
-    },
-    {
-      "label": "Somewhat agree",
-      "value": "4"
-    },
-    {
-      "label": "Neither agree nor disagree",
-      "value": "3"
-    },
-    {
-      "label": "Somewhat disagree",
-      "value": "2"
-    },
-    {
-      "label": "Strongly disagree",
-      "value": "1"
-    }],
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 5
-  }
+    "model": "user.question",
+    "pk": 6,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "opportunity",
+        "title": "To what extent do you agree or disagree there is a lot of opportunity for my business to grow internationally?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "Strongly agree",
+                "value": "5"
+            },
+            {
+                "label": "Somewhat agree",
+                "value": "4"
+            },
+            {
+                "label": "Neither agree nor disagree",
+                "value": "3"
+            },
+            {
+                "label": "Somewhat disagree",
+                "value": "2"
+            },
+            {
+                "label": "Strongly disagree",
+                "value": "1"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 5
+    }
 },
 {
-  "model": "user.question",
-  "pk": 7,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "sufficient-demand",
-    "title": "To what extent do you agree or disagree there would not be enough demand for my business overseas to make it worthwhile?",
-    "question_type": "RADIO",
-    "question_choices":
-    {
-      "options": [
-      {
-        "label": "Strongly agree",
-        "value": "5"
-      },
-      {
-        "label": "Somewhat agree",
-        "value": "4"
-      },
-      {
-        "label": "Neither agree nor disagree",
-        "value": "3"
-      },
-      {
-        "label": "Somewhat disagree",
-        "value": "2"
-      },
-      {
-        "label": "Strongly disagree",
-        "value": "1"
-      }]
-    },
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 6
-  }
+    "model": "user.question",
+    "pk": 7,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "sufficient-demand",
+        "title": "To what extent do you agree or disagree there would not be enough demand for my business overseas to make it worthwhile?",
+        "question_type": "RADIO",
+        "question_choices": {
+            "options": [
+                {
+                    "label": "Strongly agree",
+                    "value": "5"
+                },
+                {
+                    "label": "Somewhat agree",
+                    "value": "4"
+                },
+                {
+                    "label": "Neither agree nor disagree",
+                    "value": "3"
+                },
+                {
+                    "label": "Somewhat disagree",
+                    "value": "2"
+                },
+                {
+                    "label": "Strongly disagree",
+                    "value": "1"
+                }
+            ]
+        },
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 6
+    }
 },
 {
-  "model": "user.question",
-  "pk": 8,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "interested-in-support",
-    "title": "How interested would your business be in information and business support services that can assist you with exporting?",
-    "question_type": "RADIO",
-    "question_choices": [
-    {
-      "label": "Very interested",
-      "value": "3"
-    },
-    {
-      "label": "Slightly interested",
-      "value": "2"
-    },
-    {
-      "label": "Not interested",
-      "value": "1"
-    }],
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 7
-  }
+    "model": "user.question",
+    "pk": 8,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "interested-in-support",
+        "title": "How interested would your business be in information and business support services that can assist you with exporting?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "Very interested",
+                "value": "3"
+            },
+            {
+                "label": "Slightly interested",
+                "value": "2"
+            },
+            {
+                "label": "Not interested",
+                "value": "1"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 7
+    }
 },
 {
-  "model": "user.question",
-  "pk": 9,
-  "fields":
-  {
-    "created": null,
-    "modified": null,
-    "service": 1,
-    "name": "business-unit-location",
-    "title": "Where is the business unit that you regularly work in located?",
-    "question_type": "SELECT",
-    "question_choices":
-    {
-      "options": [
-      {
-        "label": "Same as Companies House address",
-        "value": "CH"
-      }],
-      "placeholder": "Select region"
-    },
-    "predefined_choices": "EXPERTISE_REGION_CHOICES",
-    "is_active": true,
-    "sort_order": 8
-  }
+    "model": "user.question",
+    "pk": 9,
+    "fields": {
+        "created": null,
+        "modified": null,
+        "service": 1,
+        "name": "business-unit-location",
+        "title": "Where is the business unit that you regularly work in located?",
+        "question_type": "SELECT",
+        "question_choices": {
+            "options": [
+                {
+                    "label": "Same as Companies House address",
+                    "value": "CH"
+                }
+            ],
+            "placeholder": "Select region"
+        },
+        "predefined_choices": "EXPERTISE_REGION_CHOICES",
+        "is_active": true,
+        "sort_order": 8
+    }
 },
 {
-  "model": "user.question",
-  "pk": 10,
-  "fields":
-  {
-    "created": null,
-    "modified": "2021-04-22T13:51:08.470Z",
-    "service": 1,
-    "name": "business-location",
-    "title": "Where is the business located?",
-    "question_type": "SELECT",
-    "question_choices":
-    {
-      "placeholder": "Select region"
-    },
-    "predefined_choices": "EXPERTISE_REGION_CHOICES",
-    "is_active": true,
-    "sort_order": 10
-  }
+    "model": "user.question",
+    "pk": 12,
+    "fields": {
+        "created": null,
+        "modified": "2021-04-22T13:51:29.180Z",
+        "service": 1,
+        "name": "employee-count",
+        "title": "How many employees are on your organisation\u2019s payroll?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "Fewer than 10",
+                "value": "<10"
+            },
+            {
+                "label": "10-49",
+                "value": "10-49"
+            },
+            {
+                "label": "50-249",
+                "value": "50-249"
+            },
+            {
+                "label": "250 or more",
+                "value": "250+"
+            },
+            {
+                "label": "I don\u2019t know / I\u2019d prefer not to say",
+                "value": "dont-know"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 12
+    }
 },
 {
-  "model": "user.question",
-  "pk": 11,
-  "fields":
-  {
-    "created": null,
-    "modified": "2021-04-22T13:51:18.416Z",
-    "service": 1,
-    "name": "company-turnover",
-    "title": "What is your organisation\u2019s annual turnover?",
-    "question_type": "RADIO",
-    "question_choices":
-    {},
-    "predefined_choices": "TURNOVER_CHOICES",
-    "is_active": true,
-    "sort_order": 11
-  }
+    "model": "user.question",
+    "pk": 13,
+    "fields": {
+        "created": "2021-04-19T09:38:33.289Z",
+        "modified": "2021-04-23T10:32:36.969Z",
+        "service": 1,
+        "name": "company",
+        "title": "Business Name",
+        "question_type": "COMPANY_LOOKUP",
+        "question_choices": {
+            "placeholder": "Business name",
+            "manualContent": "Please type in your official business name. If you are a sole trader, your business name may be the same as your name.",
+            "reviewContent": "Verify that we have imported the correct company from Companies House for your business. <p class=\"body-m m-t-xs\">Note that any incorrect details for your company need to be corrected with Companies House. </p>",
+            "searchContent": "Begin by typing the first few letters of your business name as registered with Companies House.",
+            "reviewFromProfileContent": "We\u2019ve retrieved information from Companies House for the business you\u2019ve saved in your profile. If this is the right company, select \u2018Next\u2019. Otherwise select \u2018Search\u2019 to find the correct company. <p class=\"body-m m-t-xs\">Note that any incorrect details for your company need to be corrected with Companies House. </p>"
+        },
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 8
+    }
 },
 {
-  "model": "user.question",
-  "pk": 12,
-  "fields":
-  {
-    "created": null,
-    "modified": "2021-04-22T13:51:29.180Z",
-    "service": 1,
-    "name": "employee-count",
-    "title": "How many employees are on your organisation\u2019s payroll?",
-    "question_type": "RADIO",
-    "question_choices": [
-    {
-      "label": "Fewer than 10",
-      "value": "<10"
-    },
-    {
-      "label": "10-49",
-      "value": "10-49"
-    },
-    {
-      "label": "50-249",
-      "value": "50-249"
-    },
-    {
-      "label": "250 or more",
-      "value": "250+"
-    },
-    {
-      "label": "I don\u2019t know / I\u2019d prefer not to say",
-      "value": "dont-know"
-    }],
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 12
-  }
+    "model": "user.question",
+    "pk": 15,
+    "fields": {
+        "created": "2021-04-26T13:48:05.400Z",
+        "modified": "2021-04-26T13:49:57.362Z",
+        "service": 1,
+        "name": "company-turnover-range",
+        "title": "What is your organisation\u2019s annual turnover?",
+        "question_type": "RADIO",
+        "question_choices": [
+            {
+                "label": "Below \u00a385,000",
+                "value": "Below \u00a385,000"
+            },
+            {
+                "label": "\u00a385,000 to \u00a3499,999",
+                "value": "\u00a385,000 to \u00a3499,999"
+            },
+            {
+                "label": "\u00a3500,000 to \u00a349,999,999",
+                "value": "\u00a3500,000 to \u00a349,999,999"
+            },
+            {
+                "label": "\u00a350,000,000+",
+                "value": "\u00a350,000,000+"
+            },
+            {
+                "label": "I don\u2019t know / I\u2019d prefer not to say",
+                "value": "I don\u2019t know / I\u2019d prefer not to say"
+            }
+        ],
+        "predefined_choices": null,
+        "is_active": true,
+        "sort_order": 9
+    }
 },
 {
-  "model": "user.question",
-  "pk": 13,
-  "fields":
-  {
-    "created": "2021-04-19T09:38:33.289Z",
-    "modified": "2021-04-22T13:50:50.043Z",
-    "service": 1,
-    "name": "company",
-    "title": "Business Name",
-    "question_type": "COMPANY_LOOKUP",
-    "question_choices":
-    {
-      "placeholder": "Business name",
-      "manualContent": "Please type in your official business name. If you are a sole trader, your business name may be the same as your name.",
-      "reviewContent": "Verify that we have imported the correct company from Companies House for your business. <p class=\"body-m m-t-xs\">Note that any incorrect details for your company need to be corrected with Companies House. </p>",
-      "searchContent": "Begin by typing the first few letters of your business name as registered with Companies House.",
-      "reviewFromProfileContent": "We\u2019ve retrieved information from Companies House for the business you\u2019ve saved in your profile. If this is the right company, select \u2018Next\u2019. Otherwise select \u2018Search\u2019 to find the correct company. <p class=\"body-m m-t-xs\">Note that any incorrect details for your company need to be corrected with Companies House. </p>"
-    },
-    "predefined_choices": null,
-    "is_active": true,
-    "sort_order": 9
-  }
-}]
+    "model": "user.question",
+    "pk": 16,
+    "fields": {
+        "created": "2021-04-27T08:03:25.669Z",
+        "modified": "2021-04-28T09:27:26.312Z",
+        "service": 1,
+        "name": "Sector",
+        "title": "Which sector(s) is your business in?",
+        "question_type": "MULTI_SELECT",
+        "question_choices": {},
+        "predefined_choices": "SECTORS",
+        "is_active": true,
+        "sort_order": 10
+    }
+}
+

--- a/sso/user/tests/test_utils.py
+++ b/sso/user/tests/test_utils.py
@@ -116,14 +116,15 @@ def test_get_questionnaire():
 
     utils.set_questionnaire_answer(user, service.name, second_question.id, 'answer')
     questionnaire = utils.get_questionnaire(user, service.name)
-    assert questionnaire is None
+    assert len(questionnaire['answers']) == 1
 
 
 @pytest.mark.django_db
-def stest_set_questionnaire_answer_invalid():
+def test_set_questionnaire_answer_invalid():
     user = UserFactory()
 
     assert utils.set_questionnaire_answer(user, 'service', 999, 'user_answer') is None
+    assert utils.set_questionnaire_answer(user, 'service', 999, '') is None
 
 
 @pytest.mark.django_db

--- a/sso/user/tests/test_views_api.py
+++ b/sso/user/tests/test_views_api.py
@@ -391,3 +391,14 @@ def test_set_user_questionnaire_answer(api_client):
     response = api_client.post(reverse('api:user-questionnaire'), set_data, format='json')
 
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_set_user_questionnaire_answer_invalid(api_client):
+    user = factories.UserFactory()
+    api_client.force_authenticate(user=user)
+
+    set_data = {'service': 'great', 'question_id': 99, 'answer': ''}
+
+    response = api_client.post(reverse('api:user-questionnaire'), set_data, format='json')
+    assert response.status_code == 200


### PR DESCRIPTION
This changeset removes some of the VFM logic that automatically shuts down the questionnaire on completion - because access may be needed if the user uses the back button.
The logic has moved to the FE.
Also, a later set of questions fixture with input from Suraj

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [ ] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
 - [ ] (if hotfix) Has made PR into develop too
