### PR TITLE
GP2-3071 Improve make secrets script

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,8 +39,11 @@ css:
 	./node_modules/.bin/gulp sass
 
 secrets:
-	cp conf/env/secrets-template conf/env/secrets-do-not-commit; \
-	sed -i -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' conf/env/secrets-do-not-commit
+	@if [ ! -f ./config/env/secrets-do-not-commit ]; \
+		then sed -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' config/env/secrets-template > config/env/secrets-do-not-commit \
+			&& echo "Created config/env/secrets-do-not-commit"; \
+		else echo "config/env/secrets-do-not-commit already exists. Delete first to recreate it."; \
+	fi
 
 worker:
 	ENV_FILES='secrets-do-not-commit,dev' celery -A conf worker -B -l debug

--- a/makefile
+++ b/makefile
@@ -39,10 +39,10 @@ css:
 	./node_modules/.bin/gulp sass
 
 secrets:
-	@if [ ! -f ./config/env/secrets-do-not-commit ]; \
-		then sed -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' config/env/secrets-template > config/env/secrets-do-not-commit \
-			&& echo "Created config/env/secrets-do-not-commit"; \
-		else echo "config/env/secrets-do-not-commit already exists. Delete first to recreate it."; \
+	@if [ ! -f ./conf/env/secrets-do-not-commit ]; \
+		then sed -e 's/#DO NOT ADD SECRETS TO THIS FILE//g' conf/env/secrets-template > conf/env/secrets-do-not-commit \
+			&& echo "Created conf/env/secrets-do-not-commit"; \
+		else echo "conf/env/secrets-do-not-commit already exists. Delete first to recreate it."; \
 	fi
 
 worker:


### PR DESCRIPTION
Makefile secret script now uses sed directly to create the new file to avoid using -i option, which ensures compatibility with both Mac and Linux platforms (and prevents creating extra secrets-do-not-commit-e file on Mac).

The secrets file is only created if it does not exist, otherwise user is prompted to delete if they require a fresh one.

CONTEXT: This should make onboarding and fresh setup slightly easier and more consistent when using the Docker setup from https://github.com/uktrade/great-cms

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [ ] Changelog entry added.
 - [ ] ~~(if there are vulnerable requirements) Upgraded any vulnerable dependencies.~~
 - [ ] ~~(if updating requirements) Requirements have been compiled.~~
 - [ ] ~~(if adding CSS) CSS have been compiled.~~
 - [ ] ~~(if adding HTML) Change is accessible to the standards we subscribe to.~~
 - [ ] ~~(if adding env vars) Added any new environment variable to vault.~~
 - [ ] ~~(if adding feature flags) Cleaned up old flags~~
 - [ ] ~~(if changing the UI) Add a printscreen to the PR~~
 - [ ] ~~(if hotfix) Has made PR into develop too~~
