### PR TITLE
GP2-3074-pipeline-vfm-survey 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Enhancements
 - GP2-2867 - Dockerise d-sso
 - Noticket - fix test
+- GP2-3074 - pipeline vfm survey
 
 ## [8.4.0](https://github.com/uktrade/directory-sso/releases/tag/8.4.0)
 [Compare](https://github.com/uktrade/directory-sso/compare/8.4.0...8.4.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ VOLUME /reports
 ADD . /app/
 
 RUN pip install -r requirements.txt
-
+RUN pip install -r requirements_test.txt
 

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -78,6 +78,11 @@ api_urlpatterns = [
         name='activity-stream-users',
     ),
     url(
+        r'^activity-stream/user-answers-vfm/$',
+        sso.api.views_activity_stream.ActivityStreamDirectorySSOUserAnswersVFM.as_view(),
+        name='activity-stream-user-answers-vfm',
+    ),
+    url(
         r'^verification-code/regenerate/$',
         sso.verification.views.RegenerateCodeCreateAPIView.as_view(),
         name='verification-code-regenerate',

--- a/sso/api/tests/test_views_activity_stream.py
+++ b/sso/api/tests/test_views_activity_stream.py
@@ -301,9 +301,7 @@ def test_activity_stream_list_user_answers_vfm_endpoint(api_client):
     data = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    import pdb
 
-    pdb.set_trace()
     assert len(data['orderedItems']) == 2
     assert set(data['orderedItems'][0]['object'].keys()) == {
         'id',

--- a/sso/api/tests/test_views_activity_stream.py
+++ b/sso/api/tests/test_views_activity_stream.py
@@ -2,6 +2,7 @@ import datetime
 
 import mohawk
 import pytest
+from django.core.management import call_command
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -31,6 +32,10 @@ def _url_incorrect_path():
 
 def _url_activity_stream_users():
     return 'http://testserver' + reverse('api:activity-stream-users')
+
+
+def _url_activity_stream_user_answers_vfm():
+    return 'http://testserver' + reverse('api:activity-stream-user-answers-vfm')
 
 
 def _auth_sender(key_id='some-id', secret_key='some-secret', url=_url, method='GET', content='', content_type=''):
@@ -231,6 +236,7 @@ def test_activity_stream_list_users_endpoint(api_client):
     the correct, and authentic, data is returned
     """
     UserFactory.create_batch(5)
+
     sender = _auth_sender(url=_url_activity_stream_users)
     response = api_client.get(
         _url_activity_stream_users(),
@@ -246,6 +252,66 @@ def test_activity_stream_list_users_endpoint(api_client):
         'type',
         'dit:DirectorySSO:User:email',
         'dit:DirectorySSO:User:dateJoined',
+    }
+    assert data['next'] is not None
+    assert data['previous'] is None
+
+    sender = _auth_sender(url=lambda: data['next'])
+    response = api_client.get(
+        data['next'],
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+    )
+    data = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(data['orderedItems']) == 2
+    assert data['next'] is not None
+    assert data['previous'] is not None
+
+    sender = _auth_sender(url=lambda: data['next'])
+    response = api_client.get(
+        data['next'],
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+    )
+    data = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(data['orderedItems']) == 1
+    assert data['next'] is None
+    assert data['previous'] is not None
+
+
+@pytest.mark.django_db
+def test_activity_stream_list_user_answers_vfm_endpoint(api_client):
+    """If the Authorization and X-Forwarded-For headers are correct, then
+    the correct, and authentic, data is returned
+    """
+    # Load some questions to associate
+
+    call_command('loaddata', 'test_fixtures/user_vfm_tests.json')
+
+    sender = _auth_sender(url=_url_activity_stream_user_answers_vfm)
+    response = api_client.get(
+        _url_activity_stream_user_answers_vfm(),
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+    )
+    data = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    import pdb
+
+    pdb.set_trace()
+    assert len(data['orderedItems']) == 2
+    assert set(data['orderedItems'][0]['object'].keys()) == {
+        'id',
+        'type',
+        'dit:DirectorySSO:UserAnswer:answer',
+        'dit:DirectorySSO:UserAnswer:user:id',
+        'dit:DirectorySSO:UserAnswer:question:id',
+        'dit:DirectorySSO:UserAnswer:question:title',
     }
     assert data['next'] is not None
     assert data['previous'] is None

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from sso.user import serializers
-from sso.user.models import User
+from sso.user.models import User, UserAnswer
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +131,9 @@ class ActivityStreamDirectorySSOUsers(ListAPIView):
     queryset = User.objects.all()
     serializer_class = serializers.ActivityStreamUsersSerializer
 
+    user_answer_queryset = User.objects.all()
+    user_answer_serializer_class = serializers.ActivityStreamUserAnswerSerializer
+
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
 
@@ -161,4 +164,45 @@ class ActivityStreamDirectorySSOUsers(ListAPIView):
             'previous': self.paginator.get_previous_link(),
         }
 
+        return Response(data=page)
+
+
+class ActivityStreamDirectorySSOUserAnswersVFM(ListAPIView):
+    authentication_classes = [_ActivityStreamAuthentication]
+    permission_classes = []
+
+    pagination_class = ActivityStreamDirectorySSOUsersPagination
+    queryset = UserAnswer.objects.all()
+    serializer_class = serializers.ActivityStreamUserAnswerSerializer
+
+    def get(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        queryset_page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(queryset_page, many=True)
+        page = {
+            '@context': [
+                'https://www.w3.org/ns/activitystreams',
+            ],
+            'type': 'Collection',
+            'orderedItems': [
+                {
+                    'dit:application': 'DirectorySSO',
+                    'id': f'dit:DirectorySSO:UserAnswer:{user_answer["id"]}:Update',
+                    'published': user_answer["modified"],
+                    'type': 'Update',
+                    'object': {
+                        'id': f'dit:DirectorySSO:UserAnswer:{user_answer["id"]}',
+                        'type': 'dit:DirectorySSO:UserAnswer',
+                        'dit:DirectorySSO:UserAnswer:user:id': user_answer["user_id"],
+                        'dit:DirectorySSO:UserAnswer:answer': user_answer["answer"],
+                        'dit:DirectorySSO:UserAnswer:question:id': user_answer["question_id"],
+                        'dit:DirectorySSO:UserAnswer:question:title': user_answer["question_title"],
+                    },
+                }
+                for user_answer in serializer.data
+            ],
+            'next': self.paginator.get_next_link(),
+            'previous': self.paginator.get_previous_link(),
+        }
         return Response(data=page)

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -131,9 +131,6 @@ class ActivityStreamDirectorySSOUsers(ListAPIView):
     queryset = User.objects.all()
     serializer_class = serializers.ActivityStreamUsersSerializer
 
-    user_answer_queryset = User.objects.all()
-    user_answer_serializer_class = serializers.ActivityStreamUserAnswerSerializer
-
     def get(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
 

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from rest_framework import serializers
 
 from sso.user import utils
-from sso.user.models import User, UserProfile
+from sso.user.models import User, UserAnswer, UserProfile
 from sso.verification.models import VerificationCode
 
 
@@ -106,3 +106,11 @@ class ActivityStreamUsersSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'email', 'date_joined', 'modified')
+
+
+class ActivityStreamUserAnswerSerializer(serializers.ModelSerializer):
+    question_title = serializers.CharField(source='question.title')
+
+    class Meta:
+        model = UserAnswer
+        fields = ('id', 'user_id', 'answer', 'modified', 'question_id', 'question_title')

--- a/test_fixtures/user_vfm_tests.json
+++ b/test_fixtures/user_vfm_tests.json
@@ -1,0 +1,169 @@
+[
+{
+    "model": "user.user",
+    "pk": 1,
+    "fields": {
+        "password": "pbkdf2_sha256$24000$qPsNN0ZOj885$K+9sqzUeZs80RtsZKsY9L9sT1vDgjaiMlzTcPqrpOa0=",
+        "last_login": null,
+        "is_superuser": false,
+        "created": "2017-01-08T17:56:14.305Z",
+        "modified": "2017-01-08T17:56:14.305Z",
+        "email": "load_tests25@example.com",
+        "is_staff": false,
+        "is_active": true,
+        "date_joined": "2017-01-08T17:56:14.275Z",
+        "groups": [],
+        "user_permissions": []
+    }
+},
+{
+    "model": "user.user",
+    "pk": 2,
+    "fields": {
+        "password": "pbkdf2_sha256$24000$qPsNN0ZOj885$K+9sqzUeZs80RtsZKsY9L9sT1vDgjaiMlzTcPqrpOa0=",
+        "last_login": null,
+        "is_superuser": false,
+        "created": "2017-01-08T17:56:14.305Z",
+        "modified": "2017-01-08T17:56:14.305Z",
+        "email": "load_tests24@example.com",
+        "is_staff": false,
+        "is_active": true,
+        "date_joined": "2017-01-08T17:56:14.275Z",
+        "groups": [],
+        "user_permissions": []
+    }
+},
+{
+    "model": "user.user",
+    "pk": 3,
+    "fields": {
+        "password": "pbkdf2_sha256$24000$qPsNN0ZOj885$K+9sqzUeZs80RtsZKsY9L9sT1vDgjaiMlzTcPqrpOa0=",
+        "last_login": null,
+        "is_superuser": false,
+        "created": "2017-01-08T17:56:14.305Z",
+        "modified": "2017-01-08T17:56:14.305Z",
+        "email": "load_tests23@example.com",
+        "is_staff": false,
+        "is_active": true,
+        "date_joined": "2017-01-08T17:56:14.275Z",
+        "groups": [],
+        "user_permissions": []
+    }
+},
+{
+    "model": "user.service",
+    "pk": 1,
+    "fields": {"name": "sso_tests"}
+},
+{
+    "model": "user.user",
+    "pk": 4,
+    "fields": {
+        "password": "pbkdf2_sha256$24000$qPsNN0ZOj885$K+9sqzUeZs80RtsZKsY9L9sT1vDgjaiMlzTcPqrpOa0=",
+        "last_login": null,
+        "is_superuser": false,
+        "created": "2017-01-08T17:56:14.305Z",
+        "modified": "2017-01-08T17:56:14.305Z",
+        "email": "load_tests22@example.com",
+        "is_staff": false,
+        "is_active": true,
+        "date_joined": "2017-01-08T17:56:14.275Z",
+        "groups": [],
+        "user_permissions": []
+    }
+},
+
+ {
+  "model": "user.question",
+  "pk": 1,
+  "fields":
+  {
+    "created": "2021-04-19T09:38:33.289Z",
+    "modified": "2021-05-05T14:05:39.197Z",
+    "service": 1,
+    "name": "company",
+    "title": "Business Name",
+    "question_type": "COMPANY_LOOKUP",
+    "question_choices": {
+      "placeholder": "Business name",
+      "manualContent": "Test.",
+      "reviewContent": "Test2",
+      "searchContent": "Test"
+    },
+    "predefined_choices": null,
+    "is_active": true,
+    "sort_order": 0
+  }
+},
+{
+  "model": "user.question",
+  "pk": 2,
+  "fields":
+  {
+    "created": "2021-04-26T13:48:05.400Z",
+    "modified": "2021-05-20T08:57:24.803Z",
+    "service": 1,
+    "name": "company-turnover-range",
+    "title": "What is your organisation\u2019s annual turnover in the UK?",
+    "question_type": "RADIO",
+    "question_choices": [
+    {
+      "label": "Below \u00a385,000",
+      "value": "Below \u00a385,000"
+    },
+    {
+      "label": "\u00a385,000 to \u00a3499,999",
+      "value": "\u00a385,000 to \u00a3499,999"
+    }
+  ],
+    "predefined_choices": null,
+    "is_active": true,
+    "sort_order": 12
+  }
+},
+{
+    "model": "user.useranswer",
+    "pk": 1,
+    "fields": {
+      "question": 1,
+      "user": 1,
+      "answer": {"company_name": "Test company"}
+    }
+},
+   {
+    "model": "user.useranswer",
+    "pk": 2,
+    "fields": {
+      "question": 2,
+      "user": 1,
+      "answer": "\u00a3500,000 to \u00a349,999,999"
+    }
+},
+  {
+    "model": "user.useranswer",
+    "pk": 3,
+    "fields": {
+      "question": 1,
+      "user": 2,
+      "answer": {"company_name": "Test company 2"}
+    }
+},
+   {
+    "model": "user.useranswer",
+    "pk": 4,
+    "fields": {
+      "question": 2,
+      "user": 2,
+      "answer": "\u00a8500,000 to \u00a399,999,999"
+    }
+},
+    {
+    "model": "user.useranswer",
+    "pk": 5,
+    "fields": {
+      "question": 1,
+      "user": 3,
+      "answer": {"company_name": "Test company 3"}
+    }
+}
+]


### PR DESCRIPTION
New AS activity to pull Value for Money  VFM survey into activity stream for consumption in data workspace.
We could have merged into the exiting SSOUser AS stream this would have made it simpler for maintenance but figured this is a separate usercase. Also VFM responses is probably more sensitive than USER data i.e less robust so these's value in keeping this uncoupled. So VFM responses won't break user feed. 

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [ ] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
 - [ ] (if hotfix) Has made PR into develop too
