### PR TITLE
[GP2-3344] Make account verification token based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre release
 ### Enhancements
+- GP2-3344 - Make account verification token based
 - GP2-3152 - Verification code rate limiting + reduced expiry time
 - No-ticket - removed adhoc script for data notification
 - GP2-3074 - pipeline vfm survey add questions object

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -92,6 +92,11 @@ api_urlpatterns = [
         sso.verification.views.VerifyVerificationCodeAPIView.as_view(),
         name='verification-code-verify',
     ),
+    url(
+        r'^verification-token/$',
+        sso.verification.views.VerificationTokenRetrieveAPIView.as_view(),
+        name='verification-token',
+    ),
     url(r'^user/$', sso.user.views_api.UserCreateAPIView.as_view(), name='user'),
     url(r'^user/profile/$', sso.user.views_api.UserProfileCreateAPIView.as_view(), name='user-create-profile'),
     url(r'^user/profile/update/$', sso.user.views_api.UserProfileUpdateAPIView.as_view(), name='user-update-profile'),

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -92,11 +92,6 @@ api_urlpatterns = [
         sso.verification.views.VerifyVerificationCodeAPIView.as_view(),
         name='verification-code-verify',
     ),
-    url(
-        r'^verification-token/$',
-        sso.verification.views.VerificationTokenRetrieveAPIView.as_view(),
-        name='verification-token',
-    ),
     url(r'^user/$', sso.user.views_api.UserCreateAPIView.as_view(), name='user'),
     url(r'^user/profile/$', sso.user.views_api.UserProfileCreateAPIView.as_view(), name='user-create-profile'),
     url(r'^user/profile/update/$', sso.user.views_api.UserProfileUpdateAPIView.as_view(), name='user-update-profile'),

--- a/sso/user/tests/test_views_api.py
+++ b/sso/user/tests/test_views_api.py
@@ -49,7 +49,12 @@ def test_create_user_api_valid(api_client):
 
     response = api_client.post(reverse('api:user'), {'email': new_email, 'password': password}, format='json')
     assert response.status_code == 201
-    assert response.json() == {'email': new_email, 'verification_code': mock.ANY}
+    assert response.json() == {
+        'email': new_email,
+        'verification_code': mock.ANY,
+        'uidb64': mock.ANY,
+        'verification_token': mock.ANY,
+    }
 
     assert models.User.objects.filter(email=new_email).count() == 1
 

--- a/sso/verification/helpers.py
+++ b/sso/verification/helpers.py
@@ -6,8 +6,8 @@ from django.utils.crypto import get_random_string
 
 
 class TokenGenerator(PasswordResetTokenGenerator):
-    def _make_hash_value(self, email, timestamp):
-        return six.text_type(email.pk) + six.text_type(timestamp)
+    def _make_hash_value(self, user, timestamp):
+        return six.text_type(user.pk) + six.text_type(timestamp)
 
 
 generate_verification_code = partial(get_random_string, allowed_chars='0123456789', length=5)

--- a/sso/verification/helpers.py
+++ b/sso/verification/helpers.py
@@ -1,5 +1,15 @@
 from functools import partial
 
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils import six
 from django.utils.crypto import get_random_string
 
+
+class TokenGenerator(PasswordResetTokenGenerator):
+    def _make_hash_value(self, email, timestamp):
+        return six.text_type(email.pk) + six.text_type(timestamp)
+
+
 generate_verification_code = partial(get_random_string, allowed_chars='0123456789', length=5)
+
+verification_token = TokenGenerator()

--- a/sso/verification/tests/test_view.py
+++ b/sso/verification/tests/test_view.py
@@ -83,18 +83,6 @@ def test_regenerate_code_no_user(api_client):
     assert models.VerificationCode.objects.count() == 0
 
 
-@pytest.mark.django_db
-def test_retrieve_verification_token(api_client):
-    user = UserFactory()
-    token = helpers.verification_token.make_token(user)
-    api_client.force_authenticate(user=user)
-
-    response = api_client.get(reverse('api:verification-token'))
-
-    assert response.status_code == 200
-    assert response.data['token'] == token
-
-
 @freeze_time("2018-01-14 12:00:01")
 @pytest.mark.django_db
 def test_verify_verification_code(api_client):

--- a/sso/verification/views.py
+++ b/sso/verification/views.py
@@ -2,9 +2,11 @@ from allauth.account.models import EmailAddress
 from django.contrib.auth import login
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
+from django.utils.encoding import force_text
+from django.utils.http import urlsafe_base64_decode
 from django.utils.timezone import now
 from ratelimit.decorators import ratelimit
-from rest_framework.generics import CreateAPIView, GenericAPIView
+from rest_framework.generics import CreateAPIView, GenericAPIView, RetrieveAPIView
 from rest_framework.response import Response
 
 from conf.signature import SignatureCheckPermission
@@ -33,18 +35,46 @@ class RegenerateCodeCreateAPIView(CreateAPIView):
         return get_object_or_404(models.VerificationCode.objects.all(), user__email__iexact=self.request.data['email'])
 
 
+class VerificationTokenRetrieveAPIView(RetrieveAPIView):
+    permission_classes = [SignatureCheckPermission]
+
+    def get(self):
+        token = helpers.verification_token.make_token(self.request.user.email)
+
+        return Response(status=200, data={'token': token})
+
+
 class VerifyVerificationCodeAPIView(GenericAPIView):
     serializer_class = serializers.CheckVerificationCodeSerializer
     permission_classes = [SignatureCheckPermission]
     authentication_classes = []
 
+    def get_email(self, uidb64, token):
+        try:
+            uid = force_text(urlsafe_base64_decode(uidb64))
+            email_obj = EmailAddress.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, EmailAddress.DoesNotExist):
+            email_obj = None
+
+        if email_obj is not None and helpers.verification_token.check_token(email_obj, token):
+            return email_obj.email
+
     def get_object(self):
-        return get_object_or_404(models.VerificationCode.objects.all(), user__email__iexact=self.request.data['email'])
+        uidb64 = self.request.data.get('uidb64')
+        token = self.request.data.get('token')
+
+        if uidb64 and token:
+            email = self.get_email(uidb64, token)
+        else:
+            email = self.request.data['email']
+
+        return get_object_or_404(models.VerificationCode.objects.all(), user__email__iexact=email)
 
     @method_decorator(ratelimit(key='post:email', rate='12/m', method='POST', block=True))
     def post(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data)
+
         serializer.is_valid(raise_exception=True)
         serializer.save(date_verified=now())
 

--- a/sso/verification/views.py
+++ b/sso/verification/views.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_decode
 from django.utils.timezone import now
 from ratelimit.decorators import ratelimit
-from rest_framework.generics import CreateAPIView, GenericAPIView, RetrieveAPIView
+from rest_framework.generics import CreateAPIView, GenericAPIView
 from rest_framework.response import Response
 
 from conf.signature import SignatureCheckPermission
@@ -34,15 +34,6 @@ class RegenerateCodeCreateAPIView(CreateAPIView):
 
     def get_object(self):
         return get_object_or_404(models.VerificationCode.objects.all(), user__email__iexact=self.request.data['email'])
-
-
-class VerificationTokenRetrieveAPIView(RetrieveAPIView):
-    permission_classes = [SignatureCheckPermission]
-
-    def get(self, request, *args, **kwargs):
-        token = helpers.verification_token.make_token(self.request.user)
-
-        return Response(status=200, data={'token': token})
 
 
 class VerifyVerificationCodeAPIView(GenericAPIView):


### PR DESCRIPTION
This PR enables account verification via the query parameters `uidb64` (Base64 encoded user ID) and `token` to avoid PII captures in the form of email addresses.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
