### PR TITLE
[Bugfix] Validation on password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - GP2-3074 - pipeline vfm survey add questions object
 
 ### Fixed bugs
+- GP2-3260 - Password reset validation fix
 - GP2-3017 - Added test for partial user profile update
 - GP2-2445 - JSON widget for VFM answer admin
 - GP2-2867 - Dockerise d-sso

--- a/sso/user/forms.py
+++ b/sso/user/forms.py
@@ -6,6 +6,8 @@ from allauth.utils import set_form_field_order
 from directory_components import forms
 from directory_constants import urls
 from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 from django.forms import TextInput
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -197,3 +199,11 @@ class ResetPasswordKeyForm(forms.DirectoryComponentsFormMixin, allauth.account.f
             label="Confirm password",
             label_suffix='',
         )
+
+    def clean_password1(self):
+        password1 = self.cleaned_data.get('password1')
+        try:
+            validate_password(password1)
+        except ValidationError as error:
+            self.add_error('password1', error)
+        return password1

--- a/sso/user/tests/test_forms.py
+++ b/sso/user/tests/test_forms.py
@@ -87,6 +87,52 @@ def test_password_reset_form_email_required():
     assert REQUIRED_MESSAGE in form.errors['email']
 
 
+def test_password_reset_key_form_validations_required():
+    form = forms.ResetPasswordKeyForm(data={'password1': '', 'password2': ''})
+
+    assert form.is_valid() is False
+    assert REQUIRED_MESSAGE in form.errors['password1']
+    assert REQUIRED_MESSAGE in form.errors['password2']
+
+
+def test_password_reset_key_form_validations_mismatching():
+    mismatching_message = 'You must type the same password each time.'
+    form = forms.ResetPasswordKeyForm(data={'password1': 'onetwothree123', 'password2': 'threetwoone321'})
+
+    assert form.is_valid() is False
+    assert mismatching_message in form.errors['password2']
+
+
+def test_password_reset_key_form_validations_too_short():
+    too_short_message = 'This password is too short. It must contain at least 10 characters.'
+    form = forms.ResetPasswordKeyForm(data={'password1': 'one1', 'password2': 'one1'})
+
+    assert form.is_valid() is False
+    assert too_short_message in form.errors['password1']
+
+
+def test_password_reset_key_form_validations_too_common():
+    too_common_message = 'This password is too common.'
+    form = forms.ResetPasswordKeyForm(data={'password1': 'password123', 'password2': 'password123'})
+
+    assert form.is_valid() is False
+    assert too_common_message in form.errors['password1']
+
+
+def test_password_reset_key_form_validations_entirely_numeric():
+    entirely_numeric_message = 'This password is entirely numeric.'
+    form = forms.ResetPasswordKeyForm(data={'password1': '0123456789', 'password2': '0123456789'})
+
+    assert form.is_valid() is False
+    assert entirely_numeric_message in form.errors['password1']
+
+
+def test_password_reset_key_form_validations_valid():
+    form = forms.ResetPasswordKeyForm(data={'password1': 'onetwothree1', 'password2': 'onetwothree1'})
+
+    assert form.is_valid() is True
+
+
 def test_signup_rejects_missing_terms_agreed():
     form = forms.SignupForm(data={})
 


### PR DESCRIPTION
This PR adds validation on password reset.

![image](https://user-images.githubusercontent.com/471674/134029078-f27c1526-e79f-492a-9473-4fc44c6c1928.png)

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.

