### PR TITLE
Gp2 3406 notification already registered users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre release
 ### Enhancements
+- GP2-3406 - Notifications for already registered users on sign-up
 - GP2-3344 - Make account verification token based
 - GP2-3152 - Verification code rate limiting + reduced expiry time
 - No-ticket - removed adhoc script for data notification

--- a/sso/user/forms.py
+++ b/sso/user/forms.py
@@ -5,15 +5,13 @@ from allauth.account.utils import filter_users_by_email
 from allauth.utils import set_form_field_order
 from directory_components import forms
 from directory_constants import urls
-from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.forms import TextInput
-from django.urls import reverse
 from django.utils.safestring import mark_safe
-from notifications_python_client import NotificationsAPIClient
 
 from sso.user.fields import PasswordField
+from sso.user.utils import notify_already_registered
 
 
 class SignupForm(forms.DirectoryComponentsFormMixin, allauth.account.forms.SignupForm):
@@ -79,29 +77,10 @@ class SignupForm(forms.DirectoryComponentsFormMixin, allauth.account.forms.Signu
         self.fields['password2'].widget.attrs['autocomplete'] = 'new-password'
         set_form_field_order(self, self.field_order)
 
-    @staticmethod
-    def notify_already_registered(email):
-        """
-        To prevent account enumeration in the signup form we do not inform the
-        user if the email is already registered (security requirement), instead
-        we send a notification with a link to password reset.
-        """
-        notifications_client = NotificationsAPIClient(settings.GOV_NOTIFY_API_KEY)
-
-        notifications_client.send_email_notification(
-            email_address=email,
-            template_id=settings.GOV_NOTIFY_ALREADY_REGISTERED_TEMPLATE_ID,
-            personalisation={
-                'login_url': (settings.SSO_BASE_URL + reverse('account_login')),
-                'password_reset_url': (settings.SSO_BASE_URL + reverse('account_reset_password')),
-                'contact_us_url': urls.domestic.CONTACT_US,
-            },
-        )
-
     def clean_email(self):
         value = super().clean_email()
         if EmailAddress.objects.filter(email__iexact=value).exists():
-            self.notify_already_registered(email=value)
+            notify_already_registered(email=value)
         return value
 
 

--- a/sso/user/tests/test_forms.py
+++ b/sso/user/tests/test_forms.py
@@ -3,14 +3,12 @@ from unittest.mock import patch
 
 import pytest
 from allauth.account.models import EmailAddress
-from directory_constants import urls
 from django.conf import settings
 from django.core.validators import EmailValidator
 from django.forms.fields import Field
 
 from sso.user import forms
 from sso.user.models import User
-from sso.user.utils import notify_already_registered
 
 REQUIRED_MESSAGE = Field.default_error_messages['required']
 INVALID_EMAIL_MESSAGE = EmailValidator.message
@@ -193,19 +191,3 @@ def test_password_reset_autocomplete():
     # http://stackoverflow.com/a/30976223/904887
     form = forms.ResetPasswordForm()
     assert form.fields['email'].widget.attrs['autocomplete'] == 'new-password'
-
-
-@patch('sso.user.forms.NotificationsAPIClient')
-def test_notify_already_registered(mocked_notifications):
-    notify_already_registered('test@example.com')
-    stub = mocked_notifications().send_email_notification
-    assert stub.call_count == 1
-    assert stub.call_args == mock.call(
-        email_address='test@example.com',
-        personalisation={
-            'login_url': 'http://sso.trade.great:8003/accounts/login/',
-            'password_reset_url': ('http://sso.trade.great:8003/accounts/password/reset/'),
-            'contact_us_url': urls.domestic.CONTACT_US,
-        },
-        template_id='5c8cc5aa-a4f5-48ae-89e6-df5572c317ec',
-    )

--- a/sso/user/tests/test_forms.py
+++ b/sso/user/tests/test_forms.py
@@ -10,6 +10,7 @@ from django.forms.fields import Field
 
 from sso.user import forms
 from sso.user.models import User
+from sso.user.utils import notify_already_registered
 
 REQUIRED_MESSAGE = Field.default_error_messages['required']
 INVALID_EMAIL_MESSAGE = EmailValidator.message
@@ -196,7 +197,7 @@ def test_password_reset_autocomplete():
 
 @patch('sso.user.forms.NotificationsAPIClient')
 def test_notify_already_registered(mocked_notifications):
-    forms.SignupForm.notify_already_registered('test@example.com')
+    notify_already_registered('test@example.com')
     stub = mocked_notifications().send_email_notification
     assert stub.call_count == 1
     assert stub.call_args == mock.call(

--- a/sso/user/tests/test_views_api.py
+++ b/sso/user/tests/test_views_api.py
@@ -43,7 +43,8 @@ def page_view_data():
 
 
 @pytest.mark.django_db
-def test_create_user_api_valid(api_client):
+@mock.patch('sso.user.utils.NotificationsAPIClient')
+def test_create_user_api_valid(mocked_notifications, api_client):
     new_email = 'test@test123.com'
     password = 'Abh129Jk392Hj2'
 
@@ -55,6 +56,18 @@ def test_create_user_api_valid(api_client):
         'uidb64': mock.ANY,
         'verification_token': mock.ANY,
     }
+
+    assert models.User.objects.filter(email=new_email).count() == 1
+
+
+@pytest.mark.django_db
+def test_create_user_api_duplicated_email(api_client):
+    user = factories.UserFactory()
+    new_email = user.email
+    password = 'Abh129Jk392Hj2'
+
+    response = api_client.post(reverse('api:user'), {'email': new_email, 'password': password}, format='json')
+    assert response.status_code == 409
 
     assert models.User.objects.filter(email=new_email).count() == 1
 


### PR DESCRIPTION
API endpoint for creating a user returns a `409` (conflict) response when the email address is already registered.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
