### PR TITLE
Fix send notification when already registered email is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre release
 ### Enhancements
+- GP2-3406 - Notifications for already registered users on sign-up
 - GP2-3344 - Make account verification token based
 - GP2-3152 - Verification code rate limiting + reduced expiry time
 - No-ticket - removed adhoc script for data notification

--- a/sso/user/tests/test_views_api.py
+++ b/sso/user/tests/test_views_api.py
@@ -61,7 +61,8 @@ def test_create_user_api_valid(mocked_notifications, api_client):
 
 
 @pytest.mark.django_db
-def test_create_user_api_duplicated_email(api_client):
+@mock.patch('sso.user.utils.NotificationsAPIClient')
+def test_create_user_api_duplicated_email(mocked_notifications, api_client):
     user = factories.UserFactory()
     new_email = user.email
     password = 'Abh129Jk392Hj2'

--- a/sso/user/views_api.py
+++ b/sso/user/views_api.py
@@ -25,12 +25,9 @@ class UserCreateAPIView(CreateAPIView):
     serializer_class = serializers.CreateUserSerializer
     permission_classes = [SignatureCheckPermission]
 
-    def perform_create(self, serializer):
-        super().perform_create(serializer)
-        notify_already_registered(serializer.data['email'])
-
     def handle_exception(self, exc):
         if isinstance(exc, ValidationError) and 'already exists' in str(exc):
+            notify_already_registered(self.request.data['email'])
             return Response(status=status.HTTP_409_CONFLICT)
         return super().handle_exception(exc)
 


### PR DESCRIPTION
To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
