### PR TITLE
[HOTFIX INTO MASTER] Fixes for password validation and text case of email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Noticket - fix test
 - GP2-3074 - pipeline vfm survey add questions object
 
+### Hotfix
+- GP2-3260 - Password reset validation fix
+- GP2-3104 - Treating upper and lowercase emails as being the same from User creation API endpoint
+
 ## [8.4.0](https://github.com/uktrade/directory-sso/releases/tag/8.4.0)
 [Compare](https://github.com/uktrade/directory-sso/compare/8.4.0...8.4.0)
 

--- a/sso/user/forms.py
+++ b/sso/user/forms.py
@@ -6,6 +6,8 @@ from allauth.utils import set_form_field_order
 from directory_components import forms
 from directory_constants import urls
 from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 from django.forms import TextInput
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -197,3 +199,11 @@ class ResetPasswordKeyForm(forms.DirectoryComponentsFormMixin, allauth.account.f
             label="Confirm password",
             label_suffix='',
         )
+
+    def clean_password1(self):
+        password1 = self.cleaned_data.get('password1')
+        try:
+            validate_password(password1)
+        except ValidationError as error:
+            self.add_error('password1', error)
+        return password1

--- a/sso/user/tests/test_forms.py
+++ b/sso/user/tests/test_forms.py
@@ -87,6 +87,52 @@ def test_password_reset_form_email_required():
     assert REQUIRED_MESSAGE in form.errors['email']
 
 
+def test_password_reset_key_form_validations_required():
+    form = forms.ResetPasswordKeyForm(data={'password1': '', 'password2': ''})
+
+    assert form.is_valid() is False
+    assert REQUIRED_MESSAGE in form.errors['password1']
+    assert REQUIRED_MESSAGE in form.errors['password2']
+
+
+def test_password_reset_key_form_validations_mismatching():
+    mismatching_message = 'You must type the same password each time.'
+    form = forms.ResetPasswordKeyForm(data={'password1': 'onetwothree123', 'password2': 'threetwoone321'})
+
+    assert form.is_valid() is False
+    assert mismatching_message in form.errors['password2']
+
+
+def test_password_reset_key_form_validations_too_short():
+    too_short_message = 'This password is too short. It must contain at least 10 characters.'
+    form = forms.ResetPasswordKeyForm(data={'password1': 'one1', 'password2': 'one1'})
+
+    assert form.is_valid() is False
+    assert too_short_message in form.errors['password1']
+
+
+def test_password_reset_key_form_validations_too_common():
+    too_common_message = 'This password is too common.'
+    form = forms.ResetPasswordKeyForm(data={'password1': 'password123', 'password2': 'password123'})
+
+    assert form.is_valid() is False
+    assert too_common_message in form.errors['password1']
+
+
+def test_password_reset_key_form_validations_entirely_numeric():
+    entirely_numeric_message = 'This password is entirely numeric.'
+    form = forms.ResetPasswordKeyForm(data={'password1': '0123456789', 'password2': '0123456789'})
+
+    assert form.is_valid() is False
+    assert entirely_numeric_message in form.errors['password1']
+
+
+def test_password_reset_key_form_validations_valid():
+    form = forms.ResetPasswordKeyForm(data={'password1': 'onetwothree1', 'password2': 'onetwothree1'})
+
+    assert form.is_valid() is True
+
+
 def test_signup_rejects_missing_terms_agreed():
     form = forms.SignupForm(data={})
 

--- a/sso/user/tests/test_views_api.py
+++ b/sso/user/tests/test_views_api.py
@@ -55,6 +55,19 @@ def test_create_user_api_valid(api_client):
 
 
 @pytest.mark.django_db
+def test_create_user_api_email_case_insensitive(api_client):
+    factories.UserFactory(email='TEST@example.com')
+
+    new_email = 'test@example.com'
+    password = 'Abh129Jk392Hj2'
+
+    response = api_client.post(reverse('api:user'), {'email': new_email, 'password': password}, format='json')
+
+    assert response.status_code == 409
+    assert models.User.objects.filter(email__iexact=new_email).count() == 1
+
+
+@pytest.mark.django_db
 def test_create_user_api_invalid_password(api_client):
     new_email = 'test@test123.com'
     password = 'mypassword'

--- a/sso/user/views_api.py
+++ b/sso/user/views_api.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from conf.signature import SignatureCheckPermission
 from core.authentication import SessionAuthentication
 from sso.user import serializers
-from sso.user.models import LessonCompleted, Service, UserData
+from sso.user.models import LessonCompleted, Service, User, UserData
 from sso.user.utils import (
     get_lesson_completed,
     get_page_view,
@@ -22,6 +22,14 @@ from sso.user.utils import (
 class UserCreateAPIView(CreateAPIView):
     serializer_class = serializers.CreateUserSerializer
     permission_classes = [SignatureCheckPermission]
+
+    def create(self, request, *args, **kwargs):
+        try:
+            User.objects.get(email__iexact=request.data.get('email'))
+        except ObjectDoesNotExist:
+            return super().create(request, *args, **kwargs)
+
+        return Response(status=status.HTTP_409_CONFLICT)
 
 
 class UserProfileCreateAPIView(CreateAPIView):


### PR DESCRIPTION
Hotfix into master with the following fixes:
- Reset password validation
- Make user email case insensitive from user creation API endpoint
