### PR TITLE
Add hashed uuid to users in activity stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Hotfix
 
 ### Enhancements
+- GLS-41 - Added hashed id attribute to users on Activity Stream endpoint
 
 ### Fixed bugs
 - GP2-3911 - Email Verification 

--- a/sso/api/tests/test_views_activity_stream.py
+++ b/sso/api/tests/test_views_activity_stream.py
@@ -250,6 +250,7 @@ def test_activity_stream_list_users_endpoint(api_client):
     assert set(data['orderedItems'][0]['object'].keys()) == {
         'id',
         'type',
+        'dit:DirectorySSO:User:hashedUuid',
         'dit:DirectorySSO:User:email',
         'dit:DirectorySSO:User:telephone',
         'dit:DirectorySSO:User:dateJoined',

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -151,6 +151,7 @@ class ActivityStreamDirectorySSOUsers(ListAPIView):
                     'object': {
                         'id': f'dit:DirectorySSO:User:{user["id"]}',
                         'type': 'dit:DirectorySSO:User',
+                        'dit:DirectorySSO:User:hashedUuid': user['hashed_uuid'],
                         'dit:DirectorySSO:User:email': user['email'],
                         'dit:DirectorySSO:User:telephone': user['telephone'],
                         'dit:DirectorySSO:User:dateJoined': user['date_joined'],

--- a/sso/user/serializers.py
+++ b/sso/user/serializers.py
@@ -120,7 +120,7 @@ class ActivityStreamUsersSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('id', 'email', 'telephone', 'date_joined', 'modified')
+        fields = ('id', 'hashed_uuid', 'email', 'telephone', 'date_joined', 'modified')
 
 
 class ActivityStreamUserAnswerSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
