### PR TITLE
Return 401 response when unverified user logs in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ db.sqlite3
 
 .direnv/
 
+# VS Code
+.vscode/
+
 # OSX
 
 *.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Enhancements
 
+- GLS-333 - Return 401 response from LoginView if user is unverified
+
 ### Fixed bugs
 
 - GLS-226 - Data retentions refactor

--- a/sso/adapters.py
+++ b/sso/adapters.py
@@ -5,7 +5,6 @@ from allauth.account.models import EmailAddress
 from allauth.account.utils import get_request_param
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from directory_constants.urls import domestic
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -17,8 +16,8 @@ from sso.user.models import UserProfile
 from sso.user.utils import get_url_with_redirect, is_valid_redirect
 from sso.verification import helpers
 from sso.verification.models import VerificationCode
+from sso.constants import RESEND_VERIFICATION_URL
 
-RESEND_VERIFICATION_URL = domestic.SINGLE_SIGN_ON_PROFILE / 'enrol/resend-verification/resend/'
 EMAIL_TEMPLATES = {
     'account/email/email_confirmation_signup': settings.GOV_NOTIFY_SIGNUP_CONFIRMATION_TEMPLATE_ID,
     'account/email/email_confirmation': settings.GOV_NOTIFY_SIGNUP_CONFIRMATION_TEMPLATE_ID,

--- a/sso/constants.py
+++ b/sso/constants.py
@@ -1,6 +1,10 @@
+from directory_constants.urls import domestic
+
 TERMS_AND_CONDITIONS_URL = 'https://www.exportingisgreat.gov.uk/terms-and-conditions/'
 
 EMAIL_HEADER_IMAGE = 'https://s3-eu-west-1.amazonaws.com/directory-email-static/eig-logo-stacked.png'
 
 # ISO 8601
 API_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
+
+RESEND_VERIFICATION_URL = domestic.SINGLE_SIGN_ON_PROFILE / 'enrol/resend-verification/resend/'

--- a/sso/user/tests/test_views.py
+++ b/sso/user/tests/test_views.py
@@ -170,7 +170,7 @@ def test_login_redirect_new_flow_unverified(mock_notification, client, user, set
     VerificationCode.objects.create(user=user)
     response = client.post(reverse('account_login'), {'login': user.email, 'password': 'password'})
 
-    assert response.status_code == 302
+    assert response.status_code == 401
     assert response.url == 'http://profile.trade.great:8006/profile/enrol/resend-verification/resend/'
     assert mock_notification().send_email_notification.call_count == 0
 

--- a/sso/user/views.py
+++ b/sso/user/views.py
@@ -11,6 +11,7 @@ from django.views.generic import RedirectView
 
 import core.mixins
 from sso.user import utils
+from sso.constants import RESEND_VERIFICATION_URL
 
 
 class RedirectToNextMixin:
@@ -39,6 +40,9 @@ class LoginView(RedirectToNextMixin, allauth_views.LoginView):
     def form_valid(self, form):
         response = super().form_valid(form)
         if response.status_code == 302 and response.url == reverse("account_email_verification_sent"):
+            return response
+        elif response.url == RESEND_VERIFICATION_URL:
+            response.status_code = 401
             return response
         else:
             self.request.session.save()


### PR DESCRIPTION
This PR adds logic to the `LoginView` which will return a `401` response if the user logging in has not verified their account.

This will allow the client to more easily handle when an unverified user tries to login.

**NOTE**
Won't be merged until logic to handle a 401 response is released on great-cms.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

