### PR TITLE
Bump Django from 3.2.15 to 3.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 - GLS-380 - Upgrade package to use Django 3.2 (small patch)
 - GLS-380 - Upgrade package to use Django 3.2
+- KLS-113 - Bump Django from 3.2.15 to 3.2.16
 
 ## [9.6.0](https://github.com/uktrade/directory-sso/releases/tag/9.6.0)
 [Compare](https://github.com/uktrade/directory-sso/compare/9.5.0...9.6.0)

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 dj-database-url==0.5.0
-django==3.2.15
+django==3.2.16
 django-allauth==0.51.0
 django-environ==0.4.5
 djangorestframework==3.12.2


### PR DESCRIPTION
To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 - [X] Upgraded any vulnerable dependencies.
 - [X] Requirements have been compiled.
