### PR TITLE
Bump cryptography to 41.0.7

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ requests[security]==2.31.0
 django-cryptography==1.1
 celery[redis]>=5.2.3
 django-celery-beat>=2.3.0
-cryptography==41.0.4
+cryptography==41.0.7
 django-sort-order-field==1.2
 django_json_widget==1.1.1
 urllib3==1.26.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ botocore==1.29.158
 celery[redis]==5.2.3
     # via
     #   -r requirements.in
+    #   celery
     #   django-celery-beat
 certifi==2023.7.22
     # via
@@ -49,7 +50,7 @@ click-repl==0.2.0
     # via celery
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   django-cryptography
@@ -214,6 +215,7 @@ requests[security]==2.31.0
     #   django-allauth
     #   django-oauth-toolkit
     #   notifications-python-client
+    #   requests
     #   requests-file
     #   requests-oauthlib
     #   tldextract

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -33,6 +33,7 @@ botocore==1.29.158
 celery[redis]==5.2.3
     # via
     #   -r requirements.in
+    #   celery
     #   django-celery-beat
 certifi==2023.7.22
     # via
@@ -62,7 +63,7 @@ coverage[toml]==5.5
     #   pytest-cov
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   django-cryptography
@@ -299,6 +300,7 @@ requests[security]==2.31.0
     #   django-oauth-toolkit
     #   notifications-python-client
     #   pytest-codecov
+    #   requests
     #   requests-file
     #   requests-oauthlib
     #   tldextract


### PR DESCRIPTION
Bump cryptography to 41.0.7

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1690
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers.
