### PR TITLE
Add canonical url to login pages

### DIFF
--- a/sso/templates/account/login.html
+++ b/sso/templates/account/login.html
@@ -4,7 +4,10 @@
 {% load socialaccount %}
 {% load breadcrumbs from directory_components %}
 {% block head_title %}Sign in - great.gov.uk{% endblock %}
-{% block head_other %}<meta name="robots" content="noindex">{% endblock %}
+{% block head_other %}
+  {{ block.super }}
+  <meta name="robots" content="noindex">
+  {% endblock %}
 {% block content %}
 {% breadcrumbs 'Sign in' %}
   <a href="{{ services_urls.great_domestic }}">Great.gov.uk</a>

--- a/sso/templates/account/password_reset.html
+++ b/sso/templates/account/password_reset.html
@@ -5,7 +5,9 @@
 
 {% block head_title %}{% trans "Password reset - great.gov.uk" %}{% endblock %}
 {% block head_other %}
+  {{ block.super }}
     <meta name="description" content="Reset your password for the great.gov.uk website" />
+    
 {% endblock %}
 
 {% block content %}

--- a/sso/templates/base.html
+++ b/sso/templates/base.html
@@ -1,4 +1,10 @@
 {% extends 'directory_components/base.html' %}
+{% load canonical_url_tags %}
+
+{% block head_other %}
+  {% get_canonical_url as canonical_url %}
+   <link rel="canonical" href="{{ canonical_url }}">
+{% endblock %}
 
 {% block body_content_container %}
     <main id="content" class="{% block css_layout_class %}sso-content{% endblock css_layout_class %}" role="main">

--- a/sso/templatetags/canonical_url_tags.py
+++ b/sso/templatetags/canonical_url_tags.py
@@ -1,0 +1,17 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def get_canonical_url(context):
+    request = context.get('request', None)
+    if request:
+        scheme = request.scheme
+        host = request.get_host()
+        if not host.startswith('www.'):
+            host = f'www.{host}'
+        path = request.path
+        return f'{scheme}://{host}{path}'
+    else:
+        return ''

--- a/sso/tests/test_template_tags.py
+++ b/sso/tests/test_template_tags.py
@@ -64,3 +64,9 @@ def test_get_canonical_url_without_www(rf):
     context_data = {'request': request}
     canonical_url = get_canonical_url(context_data)
     assert canonical_url == 'https://www.great.com/sso/accounts/login/password_reset'
+
+
+def test_get_canonical_url_without_request():
+    context_data = {}
+    canonical_url = get_canonical_url(context_data)
+    assert canonical_url == ''

--- a/sso/tests/test_template_tags.py
+++ b/sso/tests/test_template_tags.py
@@ -1,4 +1,3 @@
-
 from unittest.mock import MagicMock, Mock
 
 from sso import constants

--- a/sso/tests/test_template_tags.py
+++ b/sso/tests/test_template_tags.py
@@ -1,4 +1,8 @@
+
+from unittest.mock import MagicMock, Mock
+
 from sso import constants
+from sso.templatetags.canonical_url_tags import get_canonical_url
 from sso.templatetags.sso_email import header_image
 from sso.templatetags.sso_validation import is_valid_redirect_domain
 
@@ -39,3 +43,25 @@ def test_is_valid_returns_false_when_no_domain_supplied(settings):
 
     is_valid = is_valid_redirect_domain(None)
     assert is_valid is False
+
+
+def test_get_canonical_url_with_www(rf):
+    request = Mock()
+    request.scheme = 'https'
+    request.path = '/sso/accounts/login/password_reset'
+    request.get_host = MagicMock(return_value='www.great.com')
+
+    context_data = {'request': request}
+    canonical_url = get_canonical_url(context_data)
+    assert canonical_url == 'https://www.great.com/sso/accounts/login/password_reset'
+
+
+def test_get_canonical_url_without_www(rf):
+    request = Mock()
+    request.scheme = 'https'
+    request.path = '/sso/accounts/login/password_reset'
+    request.get_host = MagicMock(return_value='great.com')
+
+    context_data = {'request': request}
+    canonical_url = get_canonical_url(context_data)
+    assert canonical_url == 'https://www.great.com/sso/accounts/login/password_reset'


### PR DESCRIPTION
Add canonical url to login pages including password reset page

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-903
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
