### PR TITLE
Expose Activity Stream endpoints to the public internet

### DIFF
--- a/sso/api/tests/test_views_activity_stream.py
+++ b/sso/api/tests/test_views_activity_stream.py
@@ -57,24 +57,6 @@ def _auth_sender(key_id='some-id', secret_key='some-secret', url=_url, method='G
     'get_kwargs,expected_json',
     (
         (
-            # If X-Forwarded-For is present
-            dict(
-                content_type='',
-                HTTP_AUTHORIZATION=_auth_sender().request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
-            ),
-            {'detail': 'Public network access denied'},
-        ),
-        (
-            # Multiple X-Forwarded-For present
-            dict(
-                content_type='',
-                HTTP_AUTHORIZATION=_auth_sender().request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4,5.6.7.8',
-            ),
-            {'detail': 'Public network access denied'},
-        ),
-        (
             # If the Authorization header isn't passed
             dict(
                 content_type='',

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -65,18 +65,11 @@ class _ActivityStreamAuthentication(BaseAuthentication):
         return 'Hawk'
 
     def authenticate(self, request):
-        """Authenticates a request using two mechanisms:
+        """Authenticates a request using Hawk authentication
 
-        1. Ensure the request does not contain the X-Forwarded-For header
-           (disallow access via public network)
-        2. A Hawk signature in the Authorization header
-
-        If either of these suggest we cannot authenticate, AuthenticationFailed
-        is raised, as required in the DRF authentication flow
+        If the request is not authenticated, then a AuthenticationFailed is raised,
+        as required in the DRF authentication flow
         """
-        if 'HTTP_X_FORWARDED_FOR' in request.META:
-            logger.warning('Failed authentication: accessed from public network')
-            raise AuthenticationFailed('Public network access denied')
         return self._authenticate_by_hawk(request)
 
     def _authenticate_by_hawk(self, request):


### PR DESCRIPTION
To allow the new data-flow query the Activity Stream endpoints from outside of GOV.UK PaaS, this change removes the check on the X-Forwarded-For header that forbids any requests that contain such a header, which are the ones from the public internet.

The 3 endpoints are at the paths:

/api/v1/activity-stream/, powered by ActivityStreamViewSet
/api/v1/activity-stream/users/, powered by ActivityStreamDirectorySSOUsers
/api/v1/activity-stream/user-answers-vfm/, powered by ActivityStreamDirectorySSOUserAnswersVFM

To mitigate the increased risk by the exposure, an IP filter should be added in front of directory-sso (if it's not already running) should only allow the IP address of the new data-flow into these endpoints.

### Workflow

- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
