### PR TITLE
Fix greatuk 1595 check x forward for header

### DIFF
--- a/conf/env.py
+++ b/conf/env.py
@@ -28,6 +28,8 @@ class BaseSettings(PydanticBaseSettings):
     sentry_enable_tracing: bool = False
     sentry_traces_sample_rate: float = 1.0
 
+    safelist_ips: str = ''
+
     feature_enforce_staff_sso_enabled: bool = False
 
     staff_sso_authbroker_url: str

--- a/conf/env.py
+++ b/conf/env.py
@@ -28,7 +28,7 @@ class BaseSettings(PydanticBaseSettings):
     sentry_enable_tracing: bool = False
     sentry_traces_sample_rate: float = 1.0
 
-    safelist_ips: str = ''
+    allowed_ips: str = ''
 
     feature_enforce_staff_sso_enabled: bool = False
 

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -73,6 +73,7 @@ MIDDLEWARE = [
     'django.middleware.cache.UpdateCacheMiddleware',
     'directory_components.middleware.MaintenanceModeMiddleware',
     'core.middleware.SSODisplayLoggedInCookieMiddleware',
+    'core.middleware.XForwardForCheckMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'conf.signature.SignatureCheckMiddleware',

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -29,7 +29,7 @@ DEBUG = env.debug
 # PaaS, we can open ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 
-SAFELIST_IPS = [host.strip() for host in env.safelist_ips.split(',')]
+ALLOWED_IPS = [host.strip() for host in env.allowed_ips.split(',')]
 
 
 INSTALLED_APPS = [

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -29,6 +29,8 @@ DEBUG = env.debug
 # PaaS, we can open ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 
+SAFELIST_IPS = [host.strip() for host in env.safelist_ips.split(',')]
+
 
 INSTALLED_APPS = [
     'django.contrib.auth',

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -52,4 +52,4 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
                     if ip.strip() not in settings.ALLOWED_IPS:
                         return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
             except KeyError:
-                return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
+                pass

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -51,5 +51,5 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
                 for ip in client_ips:
                     if ip.strip() not in settings.ALLOWED_IPS:
                         return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
-            except (IndexError, KeyError):
+            except KeyError:
                 return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -56,4 +56,3 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
                 return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
             except KeyError:
                 pass
-

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -47,11 +47,10 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
         if is_copilot():
             # 200 response if client IP in x-forwarded-for header from DBT platform
             try:
-                client_ip = request.META['HTTP_X_FORWARDED_FOR'].split(',')[0]
-                if client_ip not in settings.SAFELIST_IPS:
-                    return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
+                client_ips = request.META['HTTP_X_FORWARDED_FOR'].split(',')
+                for ip in client_ips:
+                    if ip.strip() not in settings.ALLOWED_IPS:
+                        return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
             except IndexError:
                 # Return forbidden if the x-forwarded-for header does not have 0 index
                 return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
-            except KeyError:
-                pass

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -45,14 +45,11 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         if is_copilot():
-            # 200 response if client IP in x-forwarded-for header from DBT platform
+            # 200 response if client IP in x-forwarded-for header from DBT platform else 401
             try:
                 client_ips = request.META['HTTP_X_FORWARDED_FOR'].split(',')
                 for ip in client_ips:
                     if ip.strip() not in settings.ALLOWED_IPS:
                         return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
-            except IndexError:
-                # Return forbidden if the x-forwarded-for header does not have 0 index
+            except (IndexError, KeyError):
                 return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
-            except KeyError:
-                pass

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -54,3 +54,6 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
             except IndexError:
                 # Return forbidden if the x-forwarded-for header does not have 0 index
                 return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
+            except KeyError:
+                pass
+

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -45,7 +45,7 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         if is_copilot():
-            # 200 response if client IP in x-forwarded-for header from DBT platform else 401
+            # 200 response if client IP from x-forwarded-for header in ALLOWED_IPS, else 401.
             try:
                 client_ips = request.META['HTTP_X_FORWARDED_FOR'].split(',')
                 for ip in client_ips:

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -104,6 +104,7 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
 
     assert response.status_code == 200
 
+
 @pytest.mark.django_db
 def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
     os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -105,6 +105,7 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
 def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
     os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"
     settings.SAFELIST_IPS = [

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -88,9 +88,7 @@ def test_admin_permission_middleware_authorised_with_staff(client, settings, adm
 @pytest.mark.django_db
 def test_x_forward_for_middleware_with_expected_ip(client, settings):
     os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"
-    settings.ALLOWED_IPS = [
-        '1.2.3.4', '123.123.123.123'
-    ]
+    settings.ALLOWED_IPS = ['1.2.3.4', '123.123.123.123']
     reload_urlconf()
 
     # Middleware is for DBT only and should only trigger is is_copilot() is true

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -102,6 +102,7 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
 
     assert response.status_code == 200
     os.environ.pop("COPILOT_ENVIRONMENT_NAME")
+    reload_urlconf()
 
 
 @pytest.mark.django_db
@@ -123,3 +124,4 @@ def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
 
     assert response.status_code == 401
     os.environ.pop("COPILOT_ENVIRONMENT_NAME")
+    reload_urlconf()

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -102,7 +102,6 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
 
     assert response.status_code == 200
     os.environ.pop("COPILOT_ENVIRONMENT_NAME")
-    reload_urlconf()
 
 
 @pytest.mark.django_db
@@ -124,4 +123,3 @@ def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
 
     assert response.status_code == 401
     os.environ.pop("COPILOT_ENVIRONMENT_NAME")
-    reload_urlconf()

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -88,8 +88,8 @@ def test_admin_permission_middleware_authorised_with_staff(client, settings, adm
 @pytest.mark.django_db
 def test_x_forward_for_middleware_with_expected_ip(client, settings):
     os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"
-    settings.SAFELIST_IPS = [
-        '1.2.3.4',
+    settings.ALLOWED_IPS = [
+        '1.2.3.4', '123.123.123.123'
     ]
     reload_urlconf()
 
@@ -104,12 +104,11 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
 
     assert response.status_code == 200
 
-
 @pytest.mark.django_db
 def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
     os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"
-    settings.SAFELIST_IPS = [
-        '1.2.3.4.5',
+    settings.ALLOWED_IPS = [
+        '0.0.0.0',
     ]
     reload_urlconf()
 

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -101,6 +101,7 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
     )
 
     assert response.status_code == 200
+    os.environ.pop("COPILOT_ENVIRONMENT_NAME")
 
 
 @pytest.mark.django_db
@@ -121,3 +122,5 @@ def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
     )
 
     assert response.status_code == 401
+    os.environ.pop("COPILOT_ENVIRONMENT_NAME")
+

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -123,4 +123,3 @@ def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
 
     assert response.status_code == 401
     os.environ.pop("COPILOT_ENVIRONMENT_NAME")
-


### PR DESCRIPTION
As Directory SSO is not behind an IP filter it needs to check for the x-forwarded-for header in GovPaaS only. 

(Note: Although the HTTP header is called X-Forwarded-For, Django makes it available as request.META['HTTP_X_FORWARDED_FOR']. With the exception of content-length and content-type, any HTTP headers in the request are converted to request.META keys by converting all characters to uppercase, replacing any hyphens with underscores and adding an HTTP_ prefix to the name.)

The middleware I have introduced checks IP address that have been passed through via request.META['HTTP_X_FORWARDED_FOR'] against the ALLOWED_IPS settings. 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1595
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
