### PR TITLE
Changed middleware to throw 200 if one IP is found

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -47,9 +47,12 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
         if is_copilot():
             # 200 response if client IP from x-forwarded-for header in ALLOWED_IPS, else 401.
             try:
+                ip_found = False
                 client_ips = request.META['HTTP_X_FORWARDED_FOR'].split(',')
                 for ip in client_ips:
-                    if ip.strip() not in settings.ALLOWED_IPS:
-                        return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
+                    if ip.strip() in settings.ALLOWED_IPS:
+                        ip_found = True
+                if not ip_found:
+                    return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
             except KeyError:
                 pass

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -52,6 +52,7 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
                 for ip in client_ips:
                     if ip.strip() in settings.ALLOWED_IPS:
                         ip_found = True
+                        break
                 if not ip_found:
                     return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
             except KeyError:


### PR DESCRIPTION
Small PR to adjust the middleware that checks X-Forward-For headers in DBT PaaS. It now checks every IP address and only throws an error is an IP can not be found

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1595
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
