### PR TITLE
Fix greatuk 1595 check x forward in gov paas

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -44,7 +44,7 @@ class XForwardForCheckMiddleware(MiddlewareMixin):
     CLIENT_IP_ERROR_MESSAGE = 'X Forward For checks failed'
 
     def process_request(self, request):
-        if is_copilot():
+        if not is_copilot():
             # 200 response if client IP from x-forwarded-for header in ALLOWED_IPS, else 401.
             try:
                 ip_found = False

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from django.http import HttpResponse
 from django.test.client import Client

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from dbt_copilot_python.utility import is_copilot
 from django.http import HttpResponse
 from django.test.client import Client
 from django.urls import reverse

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -87,12 +87,8 @@ def test_admin_permission_middleware_authorised_with_staff(client, settings, adm
 
 @pytest.mark.django_db
 def test_x_forward_for_middleware_with_expected_ip(client, settings):
-    os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"
     settings.ALLOWED_IPS = ['1.2.3.4', '123.123.123.123']
     reload_urlconf()
-
-    # Middleware is for DBT only and should only trigger is is_copilot() is true
-    assert is_copilot() is True
 
     response = client.get(
         reverse('pingdom'),
@@ -101,19 +97,14 @@ def test_x_forward_for_middleware_with_expected_ip(client, settings):
     )
 
     assert response.status_code == 200
-    os.environ.pop("COPILOT_ENVIRONMENT_NAME")
 
 
 @pytest.mark.django_db
 def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
-    os.environ["COPILOT_ENVIRONMENT_NAME"] = "dev"
     settings.ALLOWED_IPS = [
         '0.0.0.0',
     ]
     reload_urlconf()
-
-    # Middleware is for DBT only and should only trigger is is_copilot() is true
-    assert is_copilot() is True
 
     response = client.get(
         reverse('pingdom'),
@@ -122,4 +113,3 @@ def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
     )
 
     assert response.status_code == 401
-    os.environ.pop("COPILOT_ENVIRONMENT_NAME")


### PR DESCRIPTION
This middleware is for gov paas only! I have not removed the copilot logic from the tests and added "if not is_copilot()"

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1595
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.


### Merging

- [x] This PR can be merged by reviewers.
