### PR TITLE
Fix greatuk 1595 check x forward for activity stream

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -29,7 +29,7 @@ DEBUG = env.debug
 # PaaS, we can open ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 
-ALLOWED_IPS = [host.strip() for host in env.allowed_ips.split(',')]
+ALLOWED_IPS = [ip.strip() for ip in env.allowed_ips.split(',')]
 
 
 INSTALLED_APPS = [
@@ -73,7 +73,6 @@ MIDDLEWARE = [
     'django.middleware.cache.UpdateCacheMiddleware',
     'directory_components.middleware.MaintenanceModeMiddleware',
     'core.middleware.SSODisplayLoggedInCookieMiddleware',
-    'core.middleware.XForwardForCheckMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'conf.signature.SignatureCheckMiddleware',

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -38,22 +38,3 @@ class AdminPermissionCheckMiddleware(MiddlewareMixin):
             if self.is_admin_name_space(request) or request.path_info.startswith('/admin/login'):
                 if not request.user.is_staff:
                     return HttpResponse(self.SSO_UNAUTHORISED_ACCESS_MESSAGE, status=401)
-
-
-class XForwardForCheckMiddleware(MiddlewareMixin):
-    CLIENT_IP_ERROR_MESSAGE = 'X Forward For checks failed'
-
-    def process_request(self, request):
-        if not is_copilot():
-            # 200 response if client IP from x-forwarded-for header in ALLOWED_IPS, else 401.
-            try:
-                ip_found = False
-                client_ips = request.META['HTTP_X_FORWARDED_FOR'].split(',')
-                for ip in client_ips:
-                    if ip.strip() in settings.ALLOWED_IPS:
-                        ip_found = True
-                        break
-                if not ip_found:
-                    return HttpResponse(self.CLIENT_IP_ERROR_MESSAGE, status=401)
-            except KeyError:
-                pass

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,4 +1,3 @@
-from dbt_copilot_python.utility import is_copilot
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.deprecation import MiddlewareMixin

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -80,33 +80,3 @@ def test_admin_permission_middleware_authorised_with_staff(client, settings, adm
     response = client.get(reverse('admin:login'))
 
     assert response.status_code == 302
-
-
-@pytest.mark.django_db
-def test_x_forward_for_middleware_with_expected_ip(client, settings):
-    settings.ALLOWED_IPS = ['1.2.3.4', '123.123.123.123']
-    reload_urlconf()
-
-    response = client.get(
-        reverse('pingdom'),
-        content_type='',
-        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
-    )
-
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_x_forward_for_middleware_with_unexpected_ip(client, settings):
-    settings.ALLOWED_IPS = [
-        '0.0.0.0',
-    ]
-    reload_urlconf()
-
-    response = client.get(
-        reverse('pingdom'),
-        content_type='',
-        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
-    )
-
-    assert response.status_code == 401

--- a/sso/api/tests/test_views_activity_stream.py
+++ b/sso/api/tests/test_views_activity_stream.py
@@ -169,15 +169,17 @@ def test_if_61_seconds_in_past_401_returned(api_client):
 
 
 @pytest.mark.django_db
-def test_empty_object_returned_with_authentication(api_client):
+def test_empty_object_returned_with_authentication(api_client, settings):
     """If the Authorization and X-Forwarded-For headers are correct, then
     the correct, and authentic, data is returned
     """
+    settings.ALLOWED_IPS = ['1.2.3.4', '123.123.123.123']
     sender = _auth_sender()
     response = api_client.get(
         _url(),
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
 
     assert response.status_code == status.HTTP_200_OK
@@ -213,10 +215,11 @@ def test_empty_object_returned_with_authentication(api_client):
 
 
 @pytest.mark.django_db
-def test_activity_stream_list_users_endpoint(api_client):
+def test_activity_stream_list_users_endpoint(api_client, settings):
     """If the Authorization and X-Forwarded-For headers are correct, then
     the correct, and authentic, data is returned
     """
+    settings.ALLOWED_IPS = ['1.2.3.4', '123.123.123.123']
     user_1 = UserFactory()
     UserProfileFactory(user=user_1, mobile_phone_number='824802648236868364')
     UserFactory.create_batch(4)
@@ -225,6 +228,7 @@ def test_activity_stream_list_users_endpoint(api_client):
         _url_activity_stream_users(),
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     data = response.json()
     assert response.status_code == status.HTTP_200_OK
@@ -246,6 +250,7 @@ def test_activity_stream_list_users_endpoint(api_client):
         data['next'],
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     data = response.json()
 
@@ -259,6 +264,7 @@ def test_activity_stream_list_users_endpoint(api_client):
         data['next'],
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     data = response.json()
 
@@ -269,10 +275,11 @@ def test_activity_stream_list_users_endpoint(api_client):
 
 
 @pytest.mark.django_db
-def test_activity_stream_list_user_answers_vfm_endpoint(api_client):
+def test_activity_stream_list_user_answers_vfm_endpoint(api_client, settings):
     """If the Authorization and X-Forwarded-For headers are correct, then
     the correct, and authentic, data is returned
     """
+    settings.ALLOWED_IPS = ['1.2.3.4', '123.123.123.123']
     # Load some questions to associate
 
     call_command('loaddata', 'test_fixtures/user_vfm_tests.json')
@@ -282,6 +289,7 @@ def test_activity_stream_list_user_answers_vfm_endpoint(api_client):
         _url_activity_stream_user_answers_vfm(),
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     data = response.json()
 
@@ -307,6 +315,7 @@ def test_activity_stream_list_user_answers_vfm_endpoint(api_client):
         data['next'],
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     data = response.json()
 
@@ -321,6 +330,7 @@ def test_activity_stream_list_user_answers_vfm_endpoint(api_client):
         data['next'],
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     data = response.json()
 

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -60,7 +60,7 @@ def _authorise(request):
 
 class _XForwardForCheck(permissions.BasePermission):
     """
-    Checking X-Forward-For header for IP addresses that appear in 
+    Checking X-Forward-For header for IP addresses that appear in
     settings.ALLOWED_IPS
     """
 
@@ -121,7 +121,7 @@ class _ActivityStreamHawkResponseMiddleware:
             content=response.content, content_type=response['Content-Type']
         )
         return response
-    
+
 
 class ActivityStreamViewSet(ViewSet):
     """List-only view set for the activity stream"""


### PR DESCRIPTION
The X-Forward-For header should only be checked in Gov PaaS and only for activity stream views. This PR has removed the global middleware from sso and created a new permissions class that only gets used in activity stream virews

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1595
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
