### PR TITLE
Fix greatuk 1595 add sentry logging

### DIFF
--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -81,6 +81,7 @@ class _XForwardForCheck(permissions.BasePermission):
             return False
         except KeyError:
             sentry_sdk.capture_message('Missing X-Forwarded-For header', 'warning')
+            return False
 
 
 class _ActivityStreamAuthentication(BaseAuthentication):

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -72,11 +72,12 @@ class _XForwardForCheck(permissions.BasePermission):
         if is_copilot():
             return True
         try:
-            client_ips = request.META['HTTP_X_FORWARDED_FOR'].split(',')
+            received_header = request.META['HTTP_X_FORWARDED_FOR']
+            client_ips = received_header.split(',')
             for ip in client_ips:
                 if ip.strip() in settings.ALLOWED_IPS:
                     return True
-            sentry_sdk.capture_message(f'X-Forwarded-For IP address mismatch. IPs: {request.META['HTTP_X_FORWARDED_FOR']}', 'warning')
+            sentry_sdk.capture_message(f'X-Forwarded-For IP address mismatch. IPs: {received_header}', 'warning')
             return False
         except KeyError:
             sentry_sdk.capture_message('Missing X-Forwarded-For header', 'warning')

--- a/sso/api/views_activity_stream.py
+++ b/sso/api/views_activity_stream.py
@@ -13,6 +13,8 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rest_framework import permissions
 
+import sentry_sdk
+
 from sso.user import serializers
 from sso.user.models import User, UserAnswer
 
@@ -74,9 +76,10 @@ class _XForwardForCheck(permissions.BasePermission):
             for ip in client_ips:
                 if ip.strip() in settings.ALLOWED_IPS:
                     return True
+            sentry_sdk.capture_message(f'X-Forwarded-For IP address mismatch. IPs: {request.META['HTTP_X_FORWARDED_FOR']}', 'warning')
             return False
         except KeyError:
-            return False
+            sentry_sdk.capture_message('Missing X-Forwarded-For header', 'warning')
 
 
 class _ActivityStreamAuthentication(BaseAuthentication):


### PR DESCRIPTION
Add some sentry logging to catch what is going on in PROD when activity stream urls fail.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-1595
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
